### PR TITLE
Update the idm config map to allow booting from json and using memory…

### DIFF
--- a/helm/cmp-platform/requirements.lock
+++ b/helm/cmp-platform/requirements.lock
@@ -1,24 +1,27 @@
 dependencies:
+- name: frconfig
+  repository: file://../frconfig
+  version: 6.5.0
 - name: openam
   repository: file://../openam
-  version: 6.0.0
+  version: 6.5.0
 - name: amster
   repository: file://../amster
-  version: 6.0.0
+  version: 6.5.0
 - name: opendj
   repository: file://../opendj
-  version: 6.0.0
+  version: 6.5.0
 - name: opendj
   repository: file://../opendj
-  version: 6.0.0
+  version: 6.5.0
 - name: openidm
   repository: file://../openidm
-  version: 6.0.0
+  version: 6.5.0
 - name: postgres-openidm
   repository: file://../postgres-openidm
-  version: 6.0.0
+  version: 6.5.0
 - name: openig
   repository: file://../openig
-  version: 6.0.0
-digest: sha256:afe0877d84172abd1f3c8710973882fe0507864afe72ecf67bdfb8e598e51f14
-generated: 2017-11-02T18:00:02.304173-06:00
+  version: 6.5.0
+digest: sha256:7761f2ba52d56da5967eb194667ee222596096a4c987e9e5d723d383bccf860e
+generated: 2018-05-17T12:53:28.706145785-06:00

--- a/helm/cmp-platform/requirements.yaml
+++ b/helm/cmp-platform/requirements.yaml
@@ -1,4 +1,7 @@
 dependencies:
+- name: frconfig
+  version: ">0.0.0"
+  repository: file://../frconfig
 - name: openam 
   version: ">0.0.0"
   repository: file://../openam

--- a/helm/cmp-platform/templates/NOTES.txt
+++ b/helm/cmp-platform/templates/NOTES.txt
@@ -20,7 +20,7 @@ kubectl get ing
 
 When the pods are ready, you can open up the consoles:
 
-http://openam.{{.Release.Namespace}}{{.Values.domain}}/openam
-http://openidm.{{.Release.Namespace}}{{.Values.domain}}/admin
-http://openig.{{.Release.Namespace}}{{.Values.domain}}/
+http://openam.{{.Release.Namespace}}{{.Values.openam.domain}}/openam
+http://openidm.{{.Release.Namespace}}{{.Values.openidm.domain}}/admin
+http://openig.{{.Release.Namespace}}{{.Values.openig.domain}}/
 

--- a/helm/cmp-platform/templates/git-secret.yaml
+++ b/helm/cmp-platform/templates/git-secret.yaml
@@ -1,8 +1,0 @@
-# This is a dummy secret to keep the git init containers happy. They want to mount
-# this secret - even though ssh is not required to pull from the public forgeops-init repository.
-apiVersion: v1
-kind: Secret
-data:
-  id_rsa: thisisadummykeyvalue
-metadata:
-  name: git-ssh-key

--- a/helm/openidm/templates/configmap.yaml
+++ b/helm/openidm/templates/configmap.yaml
@@ -124,19 +124,14 @@ data:
 
       # To disable the persisted configuration store set this property to false.
       # This will store the configurations only in memory.
-      # TODO: Set this conf/system.properties
-      # Review https://ea.forgerock.com/docs/idm/integrators-guide/index.html#chap-configuration 
+      # See https://ea.forgerock.com/docs/idm/integrators-guide/index.html#chap-configuration 
       openidm.config.repo.enabled=false
 
       # To stop writes to configuration files, set this property to false; suitable for read-only installations.
       felix.fileinstall.enableConfigSave=false
 
-      # To disable the JSON file monitoring you need to uncomment this line
-      openidm.fileinstall.enabled=false
-      # To disable the persisted configuration store set this property to false.
-      # This will store the configurations only in memory.
-      openidm.config.repo.enabled=false
-
+      # This needs to be true to boot from json files.
+      openidm.fileinstall.enabled=true
 
 
 ---

--- a/helm/openidm/values.yaml
+++ b/helm/openidm/values.yaml
@@ -16,7 +16,9 @@ config:
 
 image:
   repository: gcr.io/engineering-devops
-  pullPolicy: IfNotPresent
+  # For development use Always
+  pullPolicy: Always
+  #pullPolicy: IfNotPresent
   tag: 6.5.0
 
 # Specific values


### PR DESCRIPTION
Update the idm config map to allow booting from json and using memory… only config

Update cmp-platform chart to remove the dummy secret. It is now in the frconfig chart