### PR TITLE
Added cleanup step 

### DIFF
--- a/cloudbuild-smoketests.yaml
+++ b/cloudbuild-smoketests.yaml
@@ -13,6 +13,11 @@ steps:
   entrypoint: 'kubectl'
   args: ['get', 'pods']
 
+# Run remove all before tests to ensure namespace is clear before test run
+- name: 'gcr.io/engineering-devops/helm'
+  entrypoint: 'bin/remove-all.sh'
+  args: ['smoke']
+
 # Build smoke tests docker image
 - name: 'gcr.io/cloud-builders/docker'
   dir: 'cicd/forgeops-tests'


### PR DESCRIPTION
Remove-all.sh runs before deployments to make sure that testing deployments are not failing due to leftovers from failed run. 