### PR TITLE
updated routes to remove unrequired alerts

### DIFF
--- a/monitoring/values/kube-prometheus.yaml
+++ b/monitoring/values/kube-prometheus.yaml
@@ -27,31 +27,27 @@ alertmanager:
       slack_api_url: 'https://hooks.slack.com/services/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'
     route:
       group_by: [alertname]
-      #group_wait: 30s
-      #group_interval: 5m
-      #repeat_interval: 4h
+      group_wait: 30s
+      group_interval: 5m
+      repeat_interval: 4h
+      # All alerts to go to slack unless matched below
       receiver: 'slack-notifications'
       routes:
+      # Send non required alerts to null receiver
       - match:
-          alertname: DeadMansSwitch
-      #    alertname: K8SNodeNotReady
-      #    alertname: NodeDiskRunningFull
-      #    alertname: K8SApiserverDown
-      #    alertname: K8SKubeletDown
-      #    alertname: PrometheusConfigReloadFailed
-      #    alertname: PrometheusErrorSendingAlerts
-      #    alertname: PodFrequentlyRestarting
-      #    alertname: AlertmanagerFailedReload
-      #    alertname: AlertmanagerDownOrMissing
-      #    alertname: AlertmanagerConfigInconsistent
-        receiver: 'slack-notifications'
+          alertname: K8SControllerManagerDown
+        receiver: 'null'
+      - match:
+          alertname: K8SSchedulerDown
+        receiver: 'null'
       
     receivers:
+    - name: 'null'
     - name: 'slack-notifications'
       slack_configs:
       - channel: '#prometheus-alert-test'
         text: "Summary: {{ .CommonAnnotations.summary }}\nDescription: {{ .CommonAnnotations.description }}"
-        
+       
 
   ## External URL at which Alertmanager will be reachable
   ##


### PR DESCRIPTION
removed the K8S controller and scheduler notifications as these can't be monitored in GKE.