### PR TITLE
Added option to choose namespaces for Prometheus to monitor

### DIFF
--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -113,6 +113,18 @@ If you want Prometheus to scrape metrics from a different product, you need to c
         secretUser: cHJvbWV0aGV1cw==        # username in base64 encode if required
         secretPassword: cHJvbWV0aGV1cw==        # password in base64 encode if required
     ```
+* The default scope for Prometheus is to scrape all namespaces configured in values.yaml like this:
+    ```
+    namespaceSelectorStrategy: any
+    ```
+  If you want to limit this scope, you can define a list of namespace, for example:
+    ```
+    namespaceSelectorStrategy: selection
+    namespaceSelector:
+      - production
+      - staging
+      - test
+    ```
 * Update Prometheus with new ServiceMonitor
     ```
     ./bin/deploy_prometheus.sh [-n <namespace>]

--- a/monitoring/helm/forgerock-metrics/templates/am.yaml
+++ b/monitoring/helm/forgerock-metrics/templates/am.yaml
@@ -34,11 +34,14 @@ spec:
     matchLabels:
       component: {{ .Values.am.labelSelectorComponent }}
   namespaceSelector:
+    {{ if eq .Values.namespaceSelectorStrategy "any" }}
     any: true
-    #matchNames:
-      #{{- range .Values.namespaceSelector }}
-      #- {{ . }}
-      #{{- end }}
+    {{ else }}
+    matchNames:
+      {{- range .Values.namespaceSelector }}
+      - {{ . }}
+      {{- end }}
+    {{ end }}
 ---
 apiVersion: v1
 kind: Secret

--- a/monitoring/helm/forgerock-metrics/templates/ds.yaml
+++ b/monitoring/helm/forgerock-metrics/templates/ds.yaml
@@ -34,7 +34,14 @@ spec:
     matchLabels:
       component: {{ .Values.ds.labelSelectorComponent }}
   namespaceSelector:
+    {{ if eq .Values.namespaceSelectorStrategy "any" }}
     any: true
+    {{ else }}
+    matchNames:
+      {{- range .Values.namespaceSelector }}
+      - {{ . }}
+      {{- end }}
+    {{ end }}
 ---
 apiVersion: v1
 kind: Secret

--- a/monitoring/helm/forgerock-metrics/templates/idm.yaml
+++ b/monitoring/helm/forgerock-metrics/templates/idm.yaml
@@ -32,7 +32,14 @@ spec:
     matchLabels:
       component: {{ .Values.idm.labelSelectorComponent }}
   namespaceSelector:
+    {{ if eq .Values.namespaceSelectorStrategy "any" }}
     any: true
+    {{ else }}
+    matchNames:
+      {{- range .Values.namespaceSelector }}
+      - {{ . }}
+      {{- end }}
+    {{ end }}
 ---
 apiVersion: v1
 kind: Secret

--- a/monitoring/helm/forgerock-metrics/templates/ig.yaml
+++ b/monitoring/helm/forgerock-metrics/templates/ig.yaml
@@ -27,7 +27,14 @@ spec:
     matchLabels:
       component: {{ .Values.ig.labelSelectorComponent }}
   namespaceSelector:
+    {{ if eq .Values.namespaceSelectorStrategy "any" }}
     any: true
+    {{ else }}
+    matchNames:
+      {{- range .Values.namespaceSelector }}
+      - {{ . }}
+      {{- end }}
+    {{ end }}
 ---
 apiVersion: v1
 kind: Secret

--- a/monitoring/helm/forgerock-metrics/values.yaml
+++ b/monitoring/helm/forgerock-metrics/values.yaml
@@ -2,6 +2,17 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# Select namespace strategy. 
+#   any = scrape all namespaces[default].
+#   selection = user defined array of namespaces to scrape.
+namespaceSelectorStrategy: any
+# if namespaceSelectorStrategy: selected, then replace the namespace array below
+# with the namespaces to be scraped by Prometheus.
+#namespaceSelector:
+#  - production
+#  - staging
+#  - test
+
 am:
   component: am
   enabled: false


### PR DESCRIPTION
Default behaviour is for Prometheus to monitor everything but can be configured in the values.yaml to monitor a list of namespaces provided.