### PR TITLE
Added nginx & apache agent deployment to smoke test run

### DIFF
--- a/cicd/forgeops-tests/config/ProductConfig.py
+++ b/cicd/forgeops-tests/config/ProductConfig.py
@@ -17,7 +17,7 @@ class AMConfig(object):
         try:
             self.am_url = os.environ['AM_URL']
         except KeyError:
-            self.am_url = 'http://openam.example.forgeops.com/openam'
+            self.am_url = 'http://openam.smoke.forgeops.com/openam'
 
         try:
             self.amadmin_pwd = os.environ['AM_ADMIN_PWD']
@@ -33,7 +33,7 @@ class IDMConfig(object):
         try:
             self.idm_url = os.environ['IDM_URL']
         except KeyError:
-            self.idm_url = 'http://openidm.example.forgeops.com/openidm'
+            self.idm_url = 'http://openidm.smoke.forgeops.com/openidm'
 
         try:
             self.idm_admin_username = os.environ['IDM_ADMIN_USERNAME']
@@ -64,4 +64,20 @@ class IGConfig(object):
         try:
             self.ig_url = os.environ['IG_URL']
         except KeyError:
-            self.ig_url = 'http://openig.example.forgeops.com/'
+            self.ig_url = 'http://openig.smoke.forgeops.com/'
+
+
+class NginxAgentConfig(object):
+    def __init__(self):
+        try:
+            self.agent_url = os.environ['NGINX_URL']
+        except KeyError:
+            self.agent_url = 'http://nginx-agent.smoke.forgeops.com'
+
+
+class ApacheAgentConfig(object):
+    def __init__(self):
+        try:
+            self.agent_url = os.environ['APACHE_URL']
+        except KeyError:
+            self.agent_url = 'http://apache-agent.smoke.forgeops.com'

--- a/cicd/forgeops-tests/lib/agent_utils.py
+++ b/cicd/forgeops-tests/lib/agent_utils.py
@@ -1,0 +1,22 @@
+from bs4 import BeautifulSoup
+
+
+def process_autosubmit_form(resp, session):
+    """
+    Workaround method for agent autosubmit page as requests doesn't support JS
+    :param resp: Response to parse and make request as workaround for agent autosubmit page
+    :param session: Session into which store cookies
+    :return: Response from autosubmit page. As redirect is enabled by default, this will simply return originally
+             requested page
+    """
+    autosub = BeautifulSoup(resp.text, 'html.parser')
+    cdsso_url = autosub.body.form['action']
+    idtoken_value = autosub.body.form.input['value']
+    state_value = autosub.body.form.input.next_sibling['value']
+    scope_value = 'openid'
+
+    payload = {'id_token': idtoken_value,
+               'state': state_value,
+               'scope': scope_value}
+
+    return session.post(url=cdsso_url, data=payload)

--- a/cicd/forgeops-tests/tests/smoke/agents/ApacheAgentSmoke.py
+++ b/cicd/forgeops-tests/tests/smoke/agents/ApacheAgentSmoke.py
@@ -1,0 +1,54 @@
+"""
+Basic Apache agent smoke test suite
+"""
+import unittest
+from lib.agent_utils import process_autosubmit_form
+from requests import get, post, session
+
+from config.ProductConfig import ApacheAgentConfig, AMConfig
+
+
+class ApacheAgentSmoke(unittest.TestCase):
+    agent_cfg = ApacheAgentConfig()
+    amcfg = AMConfig()
+    policy_url = '/policy.html'
+    deny_policy_url = '/deny.html'
+    neu_url = '/neu.html'
+
+    def test_redirect(self):
+        resp = get(url=self.agent_cfg.agent_url, allow_redirects=False)
+        self.assertEqual(302, resp.status_code, 'Expecting 302 redirect to AM login')
+        self.assertTrue('openam' in resp.headers.get('location'), 'Expecting openam to be in location header')
+
+    def test_access_allowed_resource(self):
+        s = session()
+        s.headers = {'X-OpenAM-Username': 'user.1', 'X-OpenAM-Password': 'password',
+                     'Content-Type': 'application/json', 'Accept-API-Version': 'resource=2.0, protocol=1.0'}
+        resp = s.post(url=self.amcfg.rest_authn_url, headers=s.headers)
+        self.assertEqual(200, resp.status_code, 'User needs to login')
+
+        resp = s.get(self.agent_cfg.agent_url + self.policy_url)
+        self.assertEqual(200, resp.status_code, 'Expecting HTTP-200 from autosubmit page')
+
+        r = process_autosubmit_form(resp, s)
+        self.assertTrue('Policy testing page' in r.text, "Expecting Policy testing page string")
+        self.assertEqual(200, r.status_code, "Expecting HTTP-200 in response")
+
+        s.close()
+
+    def test_access_denied_resource(self):
+        s = session()
+        s.headers = {'X-OpenAM-Username': 'user.1', 'X-OpenAM-Password': 'password',
+                   'Content-Type': 'application/json', 'Accept-API-Version': 'resource=2.0, protocol=1.0'}
+        resp = s.post(url=self.amcfg.rest_authn_url, headers=s.headers)
+        self.assertEqual(200, resp.status_code, 'User login, expecting HTTP-200')
+
+        resp = s.get(self.agent_cfg.agent_url + self.deny_policy_url)
+        r = process_autosubmit_form(resp, s)
+        self.assertEqual(403, r.status_code, 'Expecting HTTP-403 when accessing allowed resource')
+
+        s.close()
+
+    def test_access_neu_url(self):
+        resp = get(self.agent_cfg.agent_url + self.neu_url)
+        self.assertEqual(200, resp.status_code, "Expecting to have access to NEU url")

--- a/cicd/forgeops-tests/tests/smoke/agents/NginxAgentSmoke.py
+++ b/cicd/forgeops-tests/tests/smoke/agents/NginxAgentSmoke.py
@@ -1,0 +1,54 @@
+"""
+Basic Apache agent smoke test suite
+"""
+import unittest
+from lib.agent_utils import process_autosubmit_form
+from requests import get, post, session
+
+from config.ProductConfig import NginxAgentConfig, AMConfig
+
+
+class NginxAgentSmoke(unittest.TestCase):
+    agent_cfg = NginxAgentConfig()
+    amcfg = AMConfig()
+    policy_url = '/policy.html'
+    deny_policy_url = '/deny.html'
+    neu_url = '/neu.html'
+
+    def test_redirect(self):
+        resp = get(url=self.agent_cfg.agent_url, allow_redirects=False)
+        self.assertEqual(302, resp.status_code, 'Expecting 302 redirect to AM login')
+        self.assertTrue('openam' in resp.headers.get('location'), 'Expecting openam to be in location header')
+
+    def test_access_allowed_resource(self):
+        s = session()
+        s.headers = {'X-OpenAM-Username': 'user.1', 'X-OpenAM-Password': 'password',
+                     'Content-Type': 'application/json', 'Accept-API-Version': 'resource=2.0, protocol=1.0'}
+        resp = s.post(url=self.amcfg.rest_authn_url, headers=s.headers)
+        self.assertEqual(200, resp.status_code, 'User needs to login')
+
+        resp = s.get(self.agent_cfg.agent_url + self.policy_url)
+        self.assertEqual(200, resp.status_code, 'Expecting HTTP-200 from autosubmit page')
+
+        r = process_autosubmit_form(resp, s)
+        self.assertTrue('Policy testing page' in r.text, "Expecting Policy testing page string")
+        self.assertEqual(200, r.status_code, "Expecting HTTP-200 in response")
+
+        s.close()
+
+    def test_access_denied_resource(self):
+        s = session()
+        s.headers = {'X-OpenAM-Username': 'user.1', 'X-OpenAM-Password': 'password',
+                   'Content-Type': 'application/json', 'Accept-API-Version': 'resource=2.0, protocol=1.0'}
+        resp = s.post(url=self.amcfg.rest_authn_url, headers=s.headers)
+        self.assertEqual(200, resp.status_code, 'User login, expecting HTTP-200')
+
+        resp = s.get(self.agent_cfg.agent_url + self.deny_policy_url)
+        r = process_autosubmit_form(resp, s)
+        self.assertEqual(403, r.status_code, 'Expecting HTTP-403 when accessing allowed resource')
+
+        s.close()
+
+    def test_access_neu_url(self):
+        resp = get(self.agent_cfg.agent_url + self.neu_url)
+        self.assertEqual(200, resp.status_code, "Expecting to have access to NEU url")

--- a/samples/config/smoke-deployment/amster.yaml
+++ b/samples/config/smoke-deployment/amster.yaml
@@ -2,7 +2,7 @@
 
 config:
   claim: frconfig
-  importPath: /git/config/default/am/empty-import
+  importPath: /git/config/samples/am/R6.0
   exportPath: /tmp/amster
 
 version: 6.0.0

--- a/samples/config/smoke-deployment/ctsstore.yaml
+++ b/samples/config/smoke-deployment/ctsstore.yaml
@@ -1,0 +1,2 @@
+bootstrapType: cts
+djInstance: ctsstore

--- a/samples/config/smoke-deployment/env.sh
+++ b/samples/config/smoke-deployment/env.sh
@@ -8,4 +8,4 @@ DOMAIN="forgeops.com"
 
 # The components to deploy
 # Note the opendj stores are aliased as configstore, userstore, ctstore - but they all use the opendj chart.
-COMPONENTS=(frconfig configstore userstore openam amster postgres-openidm openig openidm apache-agent nginx-agent)
+COMPONENTS=(frconfig configstore userstore ctsstore openam amster postgres-openidm openig openidm apache-agent nginx-agent)


### PR DESCRIPTION
- Added smoke tests for both agents
- Both agents are now part of forgeops smoke deployment

However until we resolve automatic agent docker image building, we are left with prebuild images, thus this smoke tests will only ensure that charts are not broken after changes. 