### PR TITLE
CLOUD-621 Updated default values for config paths, and cleaned up some comments

### DIFF
--- a/helm/amster/values.yaml
+++ b/helm/amster/values.yaml
@@ -23,14 +23,16 @@ policyAgentPassword: Passw0rd
 
 
 config:
-  strategy: git
-  # The name of the shared read write many PVC volume that holds the configuration
+  # Name of the configMap that holds the configuration repository URL and of
+  # the secret required to access it.
   name: frconfig
-  # To level path where we import the the configuration from. Your git repo will usually be mounted on /git/config
-  # in this pod.
-  importPath: /git/config/default/am/empty-import
+  # The path where we import the configuration from. Your git repo will usually be mounted on /git/config.
+  importPath: /git/config/6.5/default/am/empty-import
   # Where we perform export paths to. If not set, this defaults to the importPath
   #exportPath: /tmp/amster
+  # strategy defines how products get their configuration .
+  # Using the git strategy, each helm chart pulls the configurtion from git using an init container.
+  strategy: git
 
 image:
   repository: gcr.io/engineering-devops

--- a/helm/openam/values.yaml
+++ b/helm/openam/values.yaml
@@ -71,7 +71,7 @@ createBootstrap: true
 
 # This is an optional path to a script to execute before AM starts up. It can copy in images, update the web.xml, etc.
 # The path is *relative* to /git/config/{{ configPath.am }}.
-# For example:   /git/config/default/am/my-config/customize-am.sh
+# For example:   /git/config/6.5/my-config/am/customize-am.sh
 amCustomizationScriptPath: "customize-am.sh"
 
 # Liveness probe tuning - time in seconds

--- a/helm/openidm/values.yaml
+++ b/helm/openidm/values.yaml
@@ -10,19 +10,15 @@ domain: .forgeops.com
 # Configuration parameters. Common to all charts that require configuration from a
 # source. Currently the only source is a git repo.
 config:
-  # Path to our project
-  path: /git/config/default/idm/sync-with-ldap-bidirectional
-  # The name of the configuration we want to use. This is used as a reference 
-  # to either a pvc claim to mount that holds the configuration, or the name
-  # is used to reference secrets and a configmap that is used to clone the git repo.
-  # The default "frconfig" can be used when you want all products to share the same git repo. 
-  # You can deploy multiple instances of the frconfig chart if you want per product repos.
-  # for example,  helm install --set config.name=openig frconfig
+  # Name of the configMap that holds the configuration repository URL and of
+  # the secret required to access it.
   name: frconfig
+  # Path to our project
+  path: /git/config/6.5/default/idm/sync-with-ldap-bidirectional
   # strategy defines how products get their configuration .
-  # Using the git strategy, each helm chart pulls the configurtion from git using an init container. 
+  # Using the git strategy, each helm chart pulls the configurtion from git using an init container.
   strategy: git
-  
+
 image:
   repository: gcr.io/engineering-devops
   # For development use Always

--- a/helm/openig/values.yaml
+++ b/helm/openig/values.yaml
@@ -11,15 +11,11 @@ domain: .example.com
 # Configuration parameters. Common to all charts that require configuration from a
 # source. Currently the only source is a git repo.
 config:
-  # Path to our project
-  path: /git/config/default/ig/basic-sample
-  # The name of the configuration we want to use. This is used as a reference 
-  # to either a pvc claim to mount that holds the configuration, or the name
-  # is used to reference secrets and a configmap that is used to clone the git repo.
-  # The default "frconfig" can be used when you want all products to share the same git repo. 
-  # You can deploy multiple instances of the frconfig chart if you want per product repos.
-  # for example,  helm install --set config.name=openig frconfig
+  # Name of the configMap that holds the configuration repository URL and of
+  # the secret required to access it.
   name: frconfig
+  # Path to our project
+  path: /git/config/6.5/default/ig/basic-sample
   # strategy defines how products get their configuration .
   # Using the git strategy, each helm chart pulls the configuration from git using an init container. 
   strategy: git


### PR DESCRIPTION
I changed the default values for importPath (amster Helm chart) and path (openidm and openig Helm charts) to match Lee's recent changes to the structure of the forgeops-init repository.

I also updated some comments that referred to the version of frconfig that changed recently.