### PR TITLE
Smoke tests for IDM + updated paths for smoke tests configs 

### DIFF
--- a/cicd/forgeops-tests/config/ProductConfig.py
+++ b/cicd/forgeops-tests/config/ProductConfig.py
@@ -28,6 +28,7 @@ class AMConfig(object):
         self.rest_oauth2_authz_url = self.am_url + '/oauth2/authorize'
 
 
+
 class IDMConfig(object):
     def __init__(self):
         try:
@@ -47,6 +48,8 @@ class IDMConfig(object):
 
         self.rest_ping_url = self.idm_url + '/info/ping'
         self.rest_managed_user_url = self.idm_url + '/managed/user'
+        self.rest_selfreg_url = self.idm_url + '/selfservice/registration'
+        self.rest_selfpwreset_url = self.idm_url + '/selfservice/reset'
 
     def get_admin_headers(self, headers):
         """

--- a/cicd/forgeops-tests/tests/smoke/idm/IDMSmoke.py
+++ b/cicd/forgeops-tests/tests/smoke/idm/IDMSmoke.py
@@ -142,41 +142,41 @@ class IDMSmoke(unittest.TestCase):
             '_action': 'submitRequirements'
         }
 
-        payload = {
+        payload1 = {
             "input": {
                 'queryFilter': 'userName eq \"rsutter\"'
             }
         }
 
-        stage1 = s.post(self.idmcfg.rest_selfpwreset_url, headers=headers_init, params=params, json=payload)
+        stage1 = s.post(self.idmcfg.rest_selfpwreset_url, headers=headers_init, params=params, json=payload1)
         self.assertEqual(200, stage1.status_code, "Try to find user with query for pw reset")
 
-        payload = {
+        payload2 = {
             "token": stage1.json()["token"],
             "input": {
                 'queryFilter': 'userName eq \"rsutter\"'
             }
         }
-        stage2 = s.post(self.idmcfg.rest_selfpwreset_url, headers=headers_init, params=params, json=payload)
+        stage2 = s.post(self.idmcfg.rest_selfpwreset_url, headers=headers_init, params=params, json=payload2)
         self.assertEqual(200, stage2.status_code, "Stage 2 - Query user")
 
-        payload2 = {
+        payload3 = {
             "token": stage2.json()["token"],
             "input": {
                 "answer1": "black"
             }
         }
 
-        stage3 = s.post(self.idmcfg.rest_selfpwreset_url, headers=headers, params=params, json=payload2)
+        stage3 = s.post(self.idmcfg.rest_selfpwreset_url, headers=headers, params=params, json=payload3)
         self.assertEqual(200, stage3.status_code, "Stage 3 - Answer question")
 
-        payload3 = {
+        payload4 = {
             "token": stage3.json()["token"],
             "input": {
                 "password": "Th3Password"
             }
         }
 
-        stage4 = s.post(self.idmcfg.rest_selfpwreset_url, headers=headers, params=params, json=payload3)
+        stage4 = s.post(self.idmcfg.rest_selfpwreset_url, headers=headers, params=params, json=payload4)
         self.assertEqual(200, stage4.status_code, "Stage 4 - Password reset")
         s.close()

--- a/cicd/forgeops-tests/tests/smoke/idm/IDMSmoke.py
+++ b/cicd/forgeops-tests/tests/smoke/idm/IDMSmoke.py
@@ -8,8 +8,9 @@ Contains CRUD on user operations + running replication.
 Test are sorted automatically so that's why it's needed to keep test_0[1,2,3]_ naming.
 """
 # Lib imports
+import json
 import unittest
-from requests import get, post, put, delete
+from requests import get, post, put, delete, session
 
 # Framework imports
 from config.ProductConfig import IDMConfig
@@ -86,3 +87,96 @@ class IDMSmoke(unittest.TestCase):
         })
         resp = delete(url=self.idmcfg.rest_managed_user_url + self.testuser, headers=headers)
         self.assertEqual(200, resp.status_code, "Delete test user")
+
+    def test_6_user_self_registration(self):
+        user_data = {
+            "input": {
+                "user": {
+                    "userName": "rsutter",
+                    "givenName": "rick",
+                    "sn": "sutter",
+                    "mail": "rick@mail.com",
+                    "password": "Welcome1",
+                    "preferences": {
+                        "updates": False,
+                        "marketing": False
+                    }
+                },
+                "kba": [
+                    {
+                        "answer": "black",
+                        "questionId": "1"
+                    }
+                ]
+            }
+        }
+
+        headers = {'Content-Type': 'application/json',
+                   'X-OpenIDM-Username': 'anonymous',
+                   'X-OpenIDM-Password': 'anonymous',
+                   'Cache-Control': 'no-cache'}
+        params = {'_action': 'submitRequirements'}
+        resp = post(url=self.idmcfg.rest_selfreg_url, params=params, headers=headers, json=user_data)
+        print(resp.text)
+        self.assertEqual(200, resp.status_code)
+
+    def test_7_user_reset_pw(self):
+        s = session()
+        headers_init = {
+            'Content-Type': 'application/json',
+            'X-OpenIDM-Username': 'anonymous',
+            'X-OpenIDM-Password': 'anonymous',
+            'Cache-Control': 'no-cache',
+            'X-OpenIDM-NoSession': "true",
+            "Accept-API-Version": "protocol=1.0,resource=1.0"
+        }
+
+        headers = {
+            'Content-Type': 'application/json',
+            'X-OpenIDM-Username': 'anonymous',
+            'X-OpenIDM-Password': 'anonymous',
+            'Cache-Control': 'no-cache'
+        }
+
+        params = {
+            '_action': 'submitRequirements'
+        }
+
+        payload = {
+            "input": {
+                'queryFilter': 'userName eq \"rsutter\"'
+            }
+        }
+
+        stage1 = s.post(self.idmcfg.rest_selfpwreset_url, headers=headers_init, params=params, json=payload)
+        self.assertEqual(200, stage1.status_code, "Try to find user with query for pw reset")
+
+        payload = {
+            "token": stage1.json()["token"],
+            "input": {
+                'queryFilter': 'userName eq \"rsutter\"'
+            }
+        }
+        stage2 = s.post(self.idmcfg.rest_selfpwreset_url, headers=headers_init, params=params, json=payload)
+        self.assertEqual(200, stage2.status_code, "Stage 2 - Query user")
+
+        payload2 = {
+            "token": stage2.json()["token"],
+            "input": {
+                "answer1": "black"
+            }
+        }
+
+        stage3 = s.post(self.idmcfg.rest_selfpwreset_url, headers=headers, params=params, json=payload2)
+        self.assertEqual(200, stage3.status_code, "Stage 3 - Answer question")
+
+        payload3 = {
+            "token": stage3.json()["token"],
+            "input": {
+                "password": "Th3Password"
+            }
+        }
+
+        stage4 = s.post(self.idmcfg.rest_selfpwreset_url, headers=headers, params=params, json=payload3)
+        self.assertEqual(200, stage4.status_code, "Stage 4 - Password reset")
+        s.close()

--- a/samples/config/smoke-deployment/amster.yaml
+++ b/samples/config/smoke-deployment/amster.yaml
@@ -2,8 +2,7 @@
 
 config:
   claim: frconfig
-  importPath: /git/config/samples/am/R6.0
-  exportPath: /tmp/amster
+  importPath: /git/config/6.5/smoke-tests/am/
 
 version: 6.0.0
 

--- a/samples/config/smoke-deployment/openidm.yaml
+++ b/samples/config/smoke-deployment/openidm.yaml
@@ -1,0 +1,2 @@
+config:
+  path: /git/config/6.5/smoke-tests/idm/

--- a/samples/config/smoke-deployment/openig.yaml
+++ b/samples/config/smoke-deployment/openig.yaml
@@ -1,0 +1,2 @@
+config:
+  path: /git/config/6.5/smoke-tests/ig/


### PR DESCRIPTION
CLOUD-598: Extend IDM coverage for user registration & password change/reset

Additional change: updated paths to reflect changes in forgeops-init for smoke tests.