### PR TITLE
added Tomcat filter for CORS

### DIFF
--- a/samples/fr-platform/rs/Dockerfile
+++ b/samples/fr-platform/rs/Dockerfile
@@ -1,5 +1,6 @@
 FROM forgerock-docker-public.bintray.io/forgerock/openig:6.0.0
 
+ADD web.xml /usr/local/tomcat/webapps/ROOT/WEB-INF
 ADD config /var/openig/config
 ADD scripts /var/openig/scripts
 ADD keystore.jks /var/openig

--- a/samples/fr-platform/rs/config/routes/anonymous.json
+++ b/samples/fr-platform/rs/config/routes/anonymous.json
@@ -2,5 +2,23 @@
     "name": "anonymous",
     "baseURI": "https://idm-service.sample.svc.cluster.local:8444/",
     "condition": "${matches(request.uri.path, '^/admin') or matches(request.uri.path, '^/user') or matches(request.uri.path, '^/selfservice/') or matches(request.uri.path, '^/oauthReturn/') or matches(request.uri.path, '^/openidm/info/uiconfig') or matches(request.uri.path, '^/openidm/config/ui/themeconfig') or matches(request.uri.path, '^/openidm/identityProviders')}",
-    "handler": "IDMClient"
+    "handler": {
+        "type": "Chain",
+        "config": {
+            "filters": [
+                {
+                     "name": "AnonymousHeaders",
+                     "type": "HeaderFilter",
+                     "config": {
+                         "messageType": "REQUEST",
+                         "add": {
+                             "X-OpenIDM-Username": [ "anonymous" ],
+                             "X-OpenIDM-Password": [ "anonymous" ]
+                         }
+                     }
+                }
+            ],
+            "handler": "IDMClient"
+        }
+    }
 }

--- a/samples/fr-platform/rs/web.xml
+++ b/samples/fr-platform/rs/web.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+  The contents of this file are subject to the terms of the Common Development and
+  Distribution License (the License). You may not use this file except in compliance with the
+  License.
+
+  You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+  specific language governing permission and limitations under the License.
+
+  When distributing Covered Software, include this CDDL Header Notice in each file and include
+  the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+  Header, with the fields enclosed by brackets [] replaced by your own identifying
+  information: "Portions Copyright [year] [name of copyright owner]".
+
+  Copyright 2010-2011 ApexIdentity Inc.
+  Portions Copyright 2011-2017 ForgeRock AS.
+-->
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
+    <display-name>ForgeRock OpenIG</display-name>
+
+    <session-config>
+        <cookie-config>
+        <name>IG_SESSIONID</name>
+        </cookie-config>
+    </session-config>
+
+    <filter>
+    <filter-name>CORSFilter</filter-name>
+    <filter-class>org.apache.catalina.filters.CorsFilter</filter-class>
+    <init-param>
+    <param-name>cors.allowed.origins</param-name>
+    <param-value>*</param-value>
+    </init-param>
+    <init-param>
+    <param-name>cors.allowed.methods</param-name>
+    <param-value>GET,POST,HEAD,OPTIONS,PUT,DELETE</param-value>
+    </init-param>
+    <init-param>
+    <param-name>cors.allowed.headers</param-name>
+    <param-value>authorization</param-value>
+    </init-param>
+    <init-param>
+    <param-name>cors.support.credentials</param-name>
+    <param-value>false</param-value>
+    </init-param>
+    <init-param>
+    <param-name>cors.preflight.maxage</param-name>
+    <param-value>10</param-value>
+    </init-param>
+    </filter>
+
+    <filter-mapping>
+        <filter-name>CORSFilter</filter-name>
+        <url-pattern>/*</url-pattern>
+    </filter-mapping>
+
+</web-app>

--- a/samples/fr-platform/rs/web.xml
+++ b/samples/fr-platform/rs/web.xml
@@ -40,7 +40,7 @@
     </init-param>
     <init-param>
     <param-name>cors.allowed.headers</param-name>
-    <param-value>authorization</param-value>
+    <param-value>Content-Type,X-OpenIDM-NoSession,X-OpenIDM-Username,X-OpenIDM-Password,X-Requested-With,Cache-Control,authorization,accept,Origin,Access-Control-Request-Method,Access-Control-Request-Headers</param-value>
     </init-param>
     <init-param>
     <param-name>cors.support.credentials</param-name>


### PR DESCRIPTION
Added Tomcat filter in RS to support CORS requests otherwise rejected. Authentication via cookies is disabled; all requests require bearer token.