### PR TITLE
Removed configpath for smoke test configs (IG)

### DIFF
--- a/samples/config/smoke-deployment/openig.yaml
+++ b/samples/config/smoke-deployment/openig.yaml
@@ -1,2 +1,1 @@
-config:
-  path: /git/config/6.5/smoke-tests/ig/
+


### PR DESCRIPTION
Just removing IG config for smoke-tests