### PR TITLE
Remove second confirmation when deleting a cluster

### DIFF
--- a/bin/delete-cluster.sh
+++ b/bin/delete-cluster.sh
@@ -22,7 +22,7 @@ helm delete nginx
 
 sleep 10 
 
-gcloud container clusters delete $GKE_CLUSTER_NAME --zone $GKE_PRIMARY_ZONE
+gcloud container clusters delete $GKE_CLUSTER_NAME --zone $GKE_PRIMARY_ZONE --quiet
 
 
 


### PR DESCRIPTION
One-liner that removes the requirement of having to type "y" a second time (30-60 after typing the first y) when deleting a cluster.