### PR TITLE
transition to nfs client provisioner - WIP

### DIFF
--- a/bin/create-cluster.sh
+++ b/bin/create-cluster.sh
@@ -8,6 +8,10 @@
 
 . ../etc/gke-env.cfg
 
+GKE_NETWORK_NAME="${GKE_NETWORK_NAME:-default}"
+GKE_MONITORING_NS="${GKE_MONITORING_NS:-monitoring}"
+
+
 echo "=> Read the following env variables from config file"
 echo "Project Name = $GKE_PROJECT_NAME"
 echo "Primary Zone = $GKE_PRIMARY_ZONE"
@@ -18,6 +22,7 @@ echo "Cluster Monitoring Namespace = $GKE_MONITORING_NS"
 echo "Cluster Version = $GKE_CLUSTER_VERSION"
 echo "Cluster Size =  $GKE_CLUSTER_SIZE"
 echo "VM Type = $GKE_MACHINE_TYPE"
+echo "Network = $GKE_NETWORK_NAME"
 echo "Ingress Controller IP = $GKE_INGRESS_IP"
 echo ""
 echo "=> Do you want to continue creating the cluster with these settings?"
@@ -33,7 +38,7 @@ echo ""
 echo "=> Creating cluster called \"$GKE_CLUSTER_NAME\" with specs \"$GKE_MACHINE_TYPE\""
 echo ""
 
-MAX_NODES=`expr $GKE_CLUSTER_SIZE + 2`
+MAX_NODES=`expr $GKE_CLUSTER_SIZE + 3`
 
 OPTS=""
 
@@ -60,7 +65,7 @@ gcloud container clusters create $GKE_CLUSTER_NAME \
       --min-cpu-platform="Intel Skylake" \
       --image-type=COS \
       --disk-size=80 \
-      --network=default \
+      --network="$GKE_NETWORK_NAME" \
       --no-enable-ip-alias \
       --num-nodes=$GKE_CLUSTER_SIZE \
       --min-nodes=0 \
@@ -70,11 +75,14 @@ gcloud container clusters create $GKE_CLUSTER_NAME \
       --enable-autoscaling \
       --enable-autoupgrade \
       --enable-autorepair \
-      --scopes "gke-default" \
-      --enable-cloud-logging --enable-cloud-monitoring \
+      --scopes  "https://www.googleapis.com/auth/cloud-platform" \
+     --enable-cloud-logging --enable-cloud-monitoring \
+      --enable-ip-alias  \
       --disk-type=pd-ssd $OPTS
 
+# --scopes "https://www.googleapis.com/auth/cloud-platform"
 
+#    --enable-cloud-logging --enable-cloud-monitoring \
 # These options are no longer required or default:
 #       --enable-cloud-monitoring \
 #       --username="admin" \

--- a/bin/create-gke-filestore.sh
+++ b/bin/create-gke-filestore.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Create a Google Cloud FileStore. This is used for DS backup volumes.
+# 1TB is the smallest filestore you can create.
+# This is a WIP.
+source etc/gke-env.cfg 
+
+NETWORK="${GKE_NETWORK_NAME:-default}"
+
+gcloud beta filestore instances create shared-backup \
+    --project=engineering-devops \
+    --location=us-central1-c \
+    --tier=standard \
+    --file-share=name="export,capacity=1TB" \
+    --network="name=$NETWORK"

--- a/bin/create-nfs-client.sh
+++ b/bin/create-nfs-client.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Create an nfs client provisioner.
+# WIP: Update this when the nfs-client-provisioner is published to helm stable
+
+source etc/gke-env.cfg 
+
+NFS_SERVER=10.149.108.186
+
+
+#  --set serviceAccount.create=true \
+#      --set serviceAccount.name="nfs-service" \
+#     --set rbac.create=true \
+
+
+kubectl create namespace nfs-client
+helm delete --purge nfs-client
+helm install --name nfs-client --namespace nfs-client \
+     --set nfs.server="${NFS_SERVER}" \
+     --set nfs.path="/export" \
+     --set storageClass.provisionerName="$GKE_CLUSTER_NAME" \
+     ../../kube/charts/stable/nfs-client-provisioner

--- a/bin/gke-up.sh
+++ b/bin/gke-up.sh
@@ -13,7 +13,7 @@ ask() {
 }
 
 echo -e "WARNING: This script requires a properly provisioned GCP Project with appropriate\n\t accounts, roles, privileges, keyrings, keys etc. These pre-requisites are\n\t outlined in the DevOps Documentation. Please ensure you have completed all\n\t before proceeding."
-ask
+
 
 echo ""
 echo "=> Have you copied the template file etc/gke-env.template to etc/gke-env.cfg and edited to cater to your enviroment?"
@@ -38,7 +38,7 @@ if [ $? -ne 0 ]; then
 fi
 
 # Add a nodepool for nfs server
-./gke-create-nodepool.sh 
+#./gke-create-nodepool.sh 
 
 # Create monitoring namespace
 kubectl create namespace ${GKE_MONITORING_NS}
@@ -63,7 +63,8 @@ do
 done
 
 # Creater the NFS provisioner for backups
-./create-nfs-provisioner.sh
+# Skip this until we get client provisioner going..
+#./create-nfs-provisioner.sh
 
 # Create the ingress controller
 ./gke-ingress-cntlr.sh ${GKE_INGRESS_IP}

--- a/etc/gke-env.template
+++ b/etc/gke-env.template
@@ -34,3 +34,6 @@ GKE_MONITORING_NS="monitoring"
 # Static (External) IP Address to assign to the Ingress Controller
 # Leave  blank "" if you don't know the IP or want to dynamically set it
 GKE_INGRESS_IP=""
+
+# The vpc network that the cluster is created with
+GKE_NETWORK_NAME=default

--- a/helm/ds/values.yaml
+++ b/helm/ds/values.yaml
@@ -47,7 +47,7 @@ storageSize: "10Gi"
 backup:
   # If true this will mount a PVC of the given storage class on /opt/opendj/bak/
   enabled: false
-  storageClass: "nfs"
+  storageClass: "nfs-client"
   storageSize: "20Gi"
   # If you provide the name of a backup PVC, the default bak-$instance will NOT be created, and
   # the named pvc will be used as the shared backup volume. This can be used to re-attach 


### PR DESCRIPTION
This is a WIP - but can be tested on the shared cluster.

This creates a nfs client provisioner which uses an existing NFS server (cloud filestore). It should be much more reliable than the nfs server provisioner. 

For ds, change the backup.storageClass: nfs-client  
Instead of "nfs"

To try out the new provisioner
