### PR TITLE
Adding user create as temporary fix for smoke tests

### DIFF
--- a/cicd/forgeops-tests/config/ProductConfig.py
+++ b/cicd/forgeops-tests/config/ProductConfig.py
@@ -28,7 +28,6 @@ class AMConfig(object):
         self.rest_oauth2_authz_url = self.am_url + '/oauth2/authorize'
 
 
-
 class IDMConfig(object):
     def __init__(self):
         try:

--- a/cicd/forgeops-tests/tests/smoke/agents/ApacheAgentSmoke.py
+++ b/cicd/forgeops-tests/tests/smoke/agents/ApacheAgentSmoke.py
@@ -15,6 +15,25 @@ class ApacheAgentSmoke(unittest.TestCase):
     deny_policy_url = '/deny.html'
     neu_url = '/neu.html'
 
+    def test_0_create_test_user(self):
+        """
+                Setup a user that will be tested in user login.
+
+                """
+        headers = {'X-OpenAM-Username': 'amadmin', 'X-OpenAM-Password': 'password',
+                   'Content-Type': 'application/json', 'Accept-API-Version': 'resource=2.0, protocol=1.0'}
+        resp = post(url=self.amcfg.rest_authn_url, headers=headers)
+        self.assertEqual(200, resp.status_code, 'Admin login')
+        admin_token = resp.json()["tokenId"]
+
+        headers = {'iPlanetDirectoryPro': admin_token, 'Content-Type': 'application/json',
+                   'Accept-API-Version': 'resource=3.0, protocol=2.1'}
+        user_data = {'username': 'testuser-apache',
+                     'userpassword': 'password',
+                     'mail': 'testuser-nginx@forgerock.com'}
+        resp = post(self.amcfg.am_url + '/json/realms/root/users/?_action=create', headers=headers, json=user_data)
+        self.assertEqual(201, resp.status_code, "Expecting test user to be created - HTTP-201")
+
     def test_redirect(self):
         resp = get(url=self.agent_cfg.agent_url, allow_redirects=False)
         self.assertEqual(302, resp.status_code, 'Expecting 302 redirect to AM login')
@@ -22,7 +41,7 @@ class ApacheAgentSmoke(unittest.TestCase):
 
     def test_access_allowed_resource(self):
         s = session()
-        s.headers = {'X-OpenAM-Username': 'user.1', 'X-OpenAM-Password': 'password',
+        s.headers = {'X-OpenAM-Username': 'testuser-apache', 'X-OpenAM-Password': 'password',
                      'Content-Type': 'application/json', 'Accept-API-Version': 'resource=2.0, protocol=1.0'}
         resp = s.post(url=self.amcfg.rest_authn_url, headers=s.headers)
         self.assertEqual(200, resp.status_code, 'User needs to login')
@@ -38,7 +57,7 @@ class ApacheAgentSmoke(unittest.TestCase):
 
     def test_access_denied_resource(self):
         s = session()
-        s.headers = {'X-OpenAM-Username': 'user.1', 'X-OpenAM-Password': 'password',
+        s.headers = {'X-OpenAM-Username': 'testuser-apache', 'X-OpenAM-Password': 'password',
                    'Content-Type': 'application/json', 'Accept-API-Version': 'resource=2.0, protocol=1.0'}
         resp = s.post(url=self.amcfg.rest_authn_url, headers=s.headers)
         self.assertEqual(200, resp.status_code, 'User login, expecting HTTP-200')

--- a/cicd/forgeops-tests/tests/smoke/am/AMSmoke.py
+++ b/cicd/forgeops-tests/tests/smoke/am/AMSmoke.py
@@ -2,7 +2,7 @@
 Basic OpenAM smoke test suite.
 """
 import unittest
-from requests import get, post
+from requests import get, post, delete
 
 from config.ProductConfig import AMConfig
 
@@ -10,20 +10,53 @@ from config.ProductConfig import AMConfig
 class AMSmoke(unittest.TestCase):
     amcfg = AMConfig()
 
-    def test_ping(self):
+    def test_0_setup(self):
+        """
+        Setup a user that will be tested in user login.
+
+        """
+        headers = {'X-OpenAM-Username': 'amadmin', 'X-OpenAM-Password': 'password',
+                   'Content-Type': 'application/json', 'Accept-API-Version': 'resource=2.0, protocol=1.0'}
+        resp = post(url=self.amcfg.rest_authn_url, headers=headers)
+        self.assertEqual(200, resp.status_code, 'Admin login')
+        admin_token = resp.json()["tokenId"]
+
+        headers = {'iPlanetDirectoryPro': admin_token, 'Content-Type': 'application/json',
+                   'Accept-API-Version': 'resource=3.0, protocol=2.1'}
+        user_data = {'username': 'testuser',
+                     'userpassword': 'password',
+                     'mail': 'testuser@forgerock.com'}
+        resp = post(self.amcfg.am_url + '/json/realms/root/users/?_action=create', headers=headers, json=user_data)
+        self.assertEqual(201, resp.status_code, "Expecting test user to be created - HTTP-201")
+
+    def test_1_ping(self):
         resp = get(url=self.amcfg.am_url + '/isAlive.jsp')
         self.assertEqual(200, resp.status_code, "Ping OpenAM isAlive.jsp")
 
-    def test_admin_login(self):
+    def test_2_admin_login(self):
         headers = {'X-OpenAM-Username': 'amadmin', 'X-OpenAM-Password': 'password',
                    'Content-Type': 'application/json', 'Accept-API-Version': 'resource=2.0, protocol=1.0'}
         resp = post(url=self.amcfg.rest_authn_url, headers=headers)
         self.assertEqual(200, resp.status_code, 'Admin authn REST')
 
-    def test_user_login(self):
-        headers = {'X-OpenAM-Username': 'user.1',
+    def test_4_user_login(self):
+        headers = {'X-OpenAM-Username': 'testuser',
                    'X-OpenAM-Password': 'password',
                    'Content-Type': 'application/json',
                    'Accept-API-Version': 'resource=2.0, protocol=1.0'}
         resp = post(url=self.amcfg.rest_authn_url, headers=headers)
         self.assertEqual(200, resp.status_code, 'User authn REST')
+
+    def test_5_user_delete(self):
+
+        headers = {'X-OpenAM-Username': 'amadmin', 'X-OpenAM-Password': 'password',
+                   'Content-Type': 'application/json', 'Accept-API-Version': 'resource=2.0, protocol=1.0'}
+        resp = post(url=self.amcfg.rest_authn_url, headers=headers)
+        self.assertEqual(200, resp.status_code, 'Admin login')
+        admin_token = resp.json()["tokenId"]
+
+        headers = {'iPlanetDirectoryPro': admin_token, 'Content-Type': 'application/json',
+                   'Accept-API-Version': 'resource=3.0, protocol=2.1'}
+
+        resp = delete(self.amcfg.am_url + '/json/realms/root/users/testuser', headers=headers)
+        self.assertEqual(200, resp.status_code, "Expecting test user to be deleted - HTTP-200")


### PR DESCRIPTION
We can now remove 10 user create from DS to keep it clean. 
