### PR TITLE
Cloud 671 remove alertmanager configuration

### DIFF
--- a/bin/deploy-prometheus.sh
+++ b/bin/deploy-prometheus.sh
@@ -2,28 +2,33 @@
 # Deploys prometheus-operator Helm Chart, kube-prometheus charts and Forgerock metrics which include custom
 # endpoints, alerting rules and Grafana dashboards.
 # Script deploys to monitoring namespace by default but can be override by -n <namespace flag>
-# kube-prometheus and prometheus-operator Helm charts use values files provided in ../etc/prometheus-values.  
-# Prometheus and AlertManager can be configured via these values files.
-# forgerock-metrics uses ../etc/prometheus-values/custom.yaml which can be used to override the Helm chart values.
+
+# kube-prometheus and prometheus-operator Helm charts use values files provided in ../etc/prometheus-values. 
+# The kube-prometheus.yaml file provides configuration values for Prometheus and Alertmanager. These can be overriden by providing
+# the path to your own copy of the file using the -k <values file> flag.
+
+# forgerock-metrics uses ../etc/prometheus-values/custom.yaml which can be used to override the forgerock-metrics Helm chart values.
 # You can deploy your own custom values file by using the -f <values file> flag.
 
 MONPATH="../etc/prometheus-values"
 
-USAGE="Usage: $0 [-n <namespace>] [-f <values file>]"
+USAGE="Usage: $0 [-n <namespace>] [-f <values file>] [-k <kube-prometheus values file>]"
 
 # Output help if no arguments or -h is included
 if [[ $1 == "-h" ]];then
     echo $USAGE
     echo "-n <namespace>    namespace"
-    echo "-f <values file>  add custom values file. Default: custom.yaml"
+    echo "-f <values file>  add custom values file for forgerocks-metrics. Default: custom.yaml"
+    echo "-k <values file>  add custom values file for kube-prometheus. Default: etc/kube-prometheus.yaml"
     exit
 fi
 
 # Read arguments
-while getopts :n:f: option; do
+while getopts :n:f:k: option; do
     case "${option}" in
         n) NAMESPACE=${OPTARG};;
         f) FILE=${OPTARG};;
+        k) KFILE=${OPTARG};;
         \?) echo "Error: Incorrect usage"
             echo $USAGE
             exit 1;;
@@ -40,6 +45,13 @@ if [ $FILE ]; then
     CUSTOM_FILE="--values ${MONPATH}/${FILE}"
 fi
 
+# set location of kube-prometheus.yaml if provided as an arg, otherwise set to default in etc folder
+if [ $KFILE ]; then
+    KUBE_FILE="${KFILE}"
+else
+    KUBE_FILE="${MONPATH}/kube-prometheus.yaml"
+fi
+
 # Deploy to cluster
 if read -t 10 -p "Installing Prometheus Operator and Grafana to '${NAMESPACE}' namespace in 10 seconds or when enter is pressed...";then echo;fi
 
@@ -50,8 +62,7 @@ helm repo add coreos https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
 helm upgrade -i ${NAMESPACE}-prometheus-operator coreos/prometheus-operator --set=rbac.install=true --values ${MONPATH}/prometheus-operator.yaml --namespace=$NAMESPACE
 
 # Install/Upgrade kube-prometheus
-
-helm upgrade -i ${NAMESPACE}-kube-prometheus coreos/kube-prometheus --set=rbac.install=true -f ${MONPATH}/kube-prometheus.yaml --namespace=$NAMESPACE
+helm upgrade -i ${NAMESPACE}-kube-prometheus coreos/kube-prometheus --set=rbac.install=true -f $KUBE_FILE --namespace=$NAMESPACE
 
 # Install/Upgrade forgerock-servicemonitors
 helm upgrade -i ${NAMESPACE}-forgerock-metrics ../helm/forgerock-metrics $CUSTOM_FILE --set=rbac.install=true --namespace=$NAMESPACE

--- a/etc/prometheus-values/kube-prometheus.yaml
+++ b/etc/prometheus-values/kube-prometheus.yaml
@@ -33,29 +33,18 @@ alertmanager:
   config:
     global:
       resolve_timeout: 5m
-      slack_api_url: 'https://hooks.slack.com/services/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'
     route:
-      group_by: [alertname]
+      group_by: ['job']
       group_wait: 30s
       group_interval: 5m
-      repeat_interval: 4h
-      # All alerts to go to slack unless matched below
-      receiver: 'slack-notifications'
+      repeat_interval: 12h
+      receiver: 'null'
       routes:
-      # Send non required alerts to null receiver
       - match:
-          alertname: K8SControllerManagerDown
+          alertname: DeadMansSwitch
         receiver: 'null'
-      - match:
-          alertname: K8SSchedulerDown
-        receiver: 'null'
-      
     receivers:
     - name: 'null'
-    - name: 'slack-notifications'
-      slack_configs:
-      - channel: '#prometheus-alert-test'
-        text: "Summary: {{ .CommonAnnotations.summary }}\nDescription: {{ .CommonAnnotations.description }}"
        
 
   ## External URL at which Alertmanager will be reachable

--- a/samples/config/prometheus-values/README.md
+++ b/samples/config/prometheus-values/README.md
@@ -1,0 +1,11 @@
+# Prometheus override values
+
+The files in this directory are copies of etc/prometheus-values/kube-prometheus.yaml. They are used to provide cluster specific configuration.  
+This file contains configuration values for Prometheus and Alertmanager and flags to switch off generating metrics for specific  
+areas of the platform.
+
+The main uses of this override file will be to:
+* customize the Alertmanager configuration which determines whether to send alert notifications to a particular receiver(Slack for example).
+* customize the Prometheus configuration to apply new endpoints to capture metrics from(for example: an additional service that's running alongside FR products). 
+
+Documentation links are embedded into the override values files.

--- a/samples/config/prometheus-values/m-cluster.yaml
+++ b/samples/config/prometheus-values/m-cluster.yaml
@@ -1,0 +1,474 @@
+# exporter-node configuration
+deployExporterNode: True
+
+# set https to false for GKE. True by default for minikube
+exporter-kubelets:
+  https: false
+
+# Grafana
+deployGrafana: True
+
+# Kube-scheduler
+deployKubeScheduler: False
+
+# Controller Manager
+deployKubeControllerManager: False
+
+# Kube state
+deployKubeState: True
+
+## If true, create & use RBAC resources resp. Pod Security Policies
+##
+global:
+  rbacEnable: true
+  pspEnable: true
+
+# AlertManager
+deployAlertManager: True
+
+alertmanager:
+  ## Alertmanager configuration directives
+  ## Ref: https://prometheus.io/docs/alerting/configuration/
+  ##
+  config:
+    global:
+      resolve_timeout: 5m
+      slack_api_url: 'https://hooks.slack.com/services/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'
+    route:
+      group_by: [alertname]
+      group_wait: 30s
+      group_interval: 5m
+      repeat_interval: 4h
+      # All alerts to go to slack unless matched below
+      receiver: 'slack-notifications'
+      routes:
+      # Send non required alerts to null receiver
+      - match:
+          alertname: K8SControllerManagerDown
+        receiver: 'null'
+      - match:
+          alertname: K8SSchedulerDown
+        receiver: 'null'
+      
+    receivers:
+    - name: 'null'
+    - name: 'slack-notifications'
+      slack_configs:
+      - channel: '#alerts-medium-cluster'
+        text: "Summary: {{ .CommonAnnotations.summary }}\nDescription: {{ .CommonAnnotations.description }}"
+       
+
+  ## External URL at which Alertmanager will be reachable
+  ##
+  externalUrl: ""
+
+  ## Alertmanager container image
+  ##
+  image:
+    repository: quay.io/prometheus/alertmanager
+    tag: v0.14.0
+
+  ingress:
+    ## If true, Alertmanager Ingress will be created
+    ##
+    enabled: false
+
+    ## Annotations for Alertmanager Ingress
+    ##
+    annotations: {}
+      # kubernetes.io/ingress.class: nginx
+      # kubernetes.io/tls-acme: "true"
+
+    ## Labels to be added to the Ingress
+    ##
+    labels: {}
+
+    ## Hostnames.
+    ## Must be provided if Ingress is enabled.
+    ##
+    # hosts:
+    #   - alertmanager.domain.com
+    hosts: []
+
+    ## TLS configuration for Alertmanager Ingress
+    ## Secret must be manually created in the namespace
+    ##
+    tls: []
+      # - secretName: alertmanager-general-tls
+      #   hosts:
+      #     - alertmanager.example.com
+
+  ## Node labels for Alertmanager pod assignment
+  ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+
+  ## If true, the Operator won't process any Alertmanager configuration changes
+  ##
+  paused: false
+
+  ## Number of Alertmanager replicas desired
+  ##
+  replicaCount: 1
+
+  ## Pod anti-affinity can prevent the scheduler from placing Alertmanager replicas on the same node.
+  ## The default value "soft" means that the scheduler should *prefer* to not schedule two replica pods onto the same node but no guarantee is provided.
+  ## The value "hard" means that the scheduler is *required* to not schedule two replica pods onto the same node.
+  ## The value "" will disable pod anti-affinity so that no anti-affinity rules will be configured.
+  podAntiAffinity: "soft"
+
+  ## Resource limits & requests
+  ## Ref: https://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  resources: {}
+    # requests:
+    #   memory: 400Mi
+
+  ## List of Secrets in the same namespace as the AlertManager
+  ## object, which shall be mounted into the AlertManager Pods.
+  ## Ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#alertmanagerspec
+  ##
+  secrets: []
+
+  service:
+    ## Annotations to be added to the Service
+    ##
+    annotations: {}
+
+    ## Cluster-internal IP address for Alertmanager Service
+    ##
+    clusterIP: ""
+
+    ## List of external IP addresses at which the Alertmanager Service will be available
+    ##
+    externalIPs: []
+
+    ## External IP address to assign to Alertmanager Service
+    ## Only used if service.type is 'LoadBalancer' and supported by cloud provider
+    ##
+    loadBalancerIP: ""
+
+    ## List of client IPs allowed to access Alertmanager Service
+    ## Only used if service.type is 'LoadBalancer' and supported by cloud provider
+    ##
+    loadBalancerSourceRanges: []
+
+    ## Port to expose on each node
+    ## Only used if service.type is 'NodePort'
+    ##
+    nodePort: 30903
+
+    ## Service type
+    ##
+    type: ClusterIP
+
+  ## Alertmanager StorageSpec for persistent data
+  ## Ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/user-guides/storage.md
+  ##
+  storageSpec: {}
+  #  volumeClaimTemplate:
+  #    spec:
+  #      storageClassName: gluster
+  #      accessModes: ["ReadWriteOnce"]
+  #      resources:
+  #        requests:
+  #          storage: 50Gi
+  #    selector: {}
+
+prometheus:
+  ## Alertmanagers to which alerts will be sent
+  ## Ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#alertmanagerendpoints
+  ##
+  alertingEndpoints: []
+  #   - name: ""
+  #     namespace: ""
+  #     port: 9093
+  #     scheme: http
+
+  ## Prometheus configuration directives
+  ## Ignored if serviceMonitors are defined
+  ## Ref: https://prometheus.io/docs/operating/configuration/
+  ##
+  config:
+    specifiedInValues: true
+    value: {}
+
+  ## External URL at which Prometheus will be reachable
+  ##
+  externalUrl: ""
+
+  ## Prometheus container image
+  ##
+  image:
+    repository: quay.io/prometheus/prometheus
+    tag: v2.2.1
+
+  ingress:
+    ## If true, Prometheus Ingress will be created
+    ##
+    enabled: false
+
+    ## Annotations for Prometheus Ingress
+    ##
+    annotations: {}
+      # kubernetes.io/ingress.class: nginx
+      # kubernetes.io/tls-acme: "true"
+
+    ## Labels to be added to the Ingress
+    ##
+    labels: {}
+
+    ## Hostnames.
+    ## Must be provided if Ingress is enabled.
+    ##
+    # hosts:
+    #   - alertmanager.domain.com
+    hosts: []
+
+    ## TLS configuration for Prometheus Ingress
+    ## Secret must be manually created in the namespace
+    ##
+    tls: []
+      # - secretName: prometheus-k8s-tls
+      #   hosts:
+      #     - prometheus.example.com
+
+  ## Node labels for Prometheus pod assignment
+  ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+
+  ## If true, the Operator won't process any Prometheus configuration changes
+  ##
+  paused: false
+
+  ## Number of Prometheus replicas desired
+  ##
+  replicaCount: 1
+
+  ## Pod anti-affinity can prevent the scheduler from placing Prometheus replicas on the same node.
+  ## The default value "soft" means that the scheduler should *prefer* to not schedule two replica pods onto the same node but no guarantee is provided.
+  ## The value "hard" means that the scheduler is *required* to not schedule two replica pods onto the same node.
+  ## The value "" will disable pod anti-affinity so that no anti-affinity rules will be configured.
+  podAntiAffinity: "soft"
+
+  ## Resource limits & requests
+  ## Ref: https://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  resources: {}
+    # requests:
+    #   memory: 400Mi
+
+  ## List of Secrets in the same namespace as the Prometheus
+  ## object, which shall be mounted into the Prometheus Pods.
+  ## Ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec
+  ##
+  secrets: []
+
+  ## How long to retain metrics
+  ##
+  retention: 30d
+
+  ## Prefix used to register routes, overriding externalUrl route.
+  ## Useful for proxies that rewrite URLs.
+  ##
+  routePrefix: /
+
+  ## Rules configmap selector
+  ## Ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/design.md
+  ##
+  ## 1. If `matchLabels` is used, `rules.additionalLabels` must contain all the labels from
+  ##    `matchLabels` in order to be be matched by Prometheus
+  ## 2. If `matchExpressions` is used `rules.additionalLabels` must contain at least one label
+  ##    from `matchExpressions` in order to be matched by Prometheus
+  ## Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
+  #rulesSelector: {}
+   #rulesSelector: {
+   #   matchExpressions: [{key: prometheus, operator: In, values: [example-rules, example-rules-2]}]
+   # }
+   ### OR
+  #rulesSelector:
+  #  matchLabels: 
+  #    role: alert-rules
+  #    prometheus: monitoring-kube-prometheus
+
+
+  ## Prometheus alerting & recording rules
+  ## Ref: https://prometheus.io/docs/querying/rules/
+  ## Ref: https://prometheus.io/docs/alerting/rules/
+  ##
+  rules:
+    specifiedInValues: true
+    ## What additional rules to be added to the ConfigMap
+    ## You can use this together with `rulesSelector`
+    additionalLabels:
+      role: alert-rules
+      prometheus: monitoring-kube-prometheus
+    value: {}
+
+  service:
+    ## Annotations to be added to the Service
+    ##
+    annotations: {}
+
+    ## Cluster-internal IP address for Prometheus Service
+    ##
+    clusterIP: ""
+
+    ## List of external IP addresses at which the Prometheus Service will be available
+    ##
+    externalIPs: []
+
+    ## External IP address to assign to Prometheus Service
+    ## Only used if service.type is 'LoadBalancer' and supported by cloud provider
+    ##
+    loadBalancerIP: ""
+
+    ## List of client IPs allowed to access Prometheus Service
+    ## Only used if service.type is 'LoadBalancer' and supported by cloud provider
+    ##
+    loadBalancerSourceRanges: []
+
+    ## Port to expose on each node
+    ## Only used if service.type is 'NodePort'
+    ##
+    nodePort: 30900
+
+    ## Service type
+    ##
+    type: ClusterIP
+
+  ## Service monitors selector
+  ## Ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/design.md
+  ##
+  serviceMonitorsSelector:
+    matchExpressions:
+    - key: app
+      operator: In
+      values:
+      - alertmanager
+      - exporter-coredns
+      - exporter-kube-dns
+      - exporter-kube-etcd
+      - exporter-kube-state
+      - exporter-kubelets
+      - exporter-kubernetes
+      - exporter-node
+      - grafana
+      - prometheus
+      - prometheus-operator
+      - am
+      - ds
+      - idm
+      - ig
+
+  ## ServiceMonitor CRDs to create & be scraped by the Prometheus instance.
+  ## Ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/service-monitor.md
+  ##
+  serviceMonitors: []
+    ## Name of the ServiceMonitor to create
+    ##
+    # - name: ""
+
+      ## Service label for use in assembling a job name of the form <label value>-<port>
+      ## If no label is specified, the service name is used.
+      ##
+      # jobLabel: ""
+
+      ## Label selector for services to which this ServiceMonitor applies
+      ##
+      # selector: {}
+
+      ## Namespaces from which services are selected
+      ##
+      # namespaceSelector:
+        ## Match any namespace
+        ##
+        # any: false
+
+        ## Explicit list of namespace names to select
+        ##
+        # matchNames: []
+
+      ## Endpoints of the selected service to be monitored
+      ##
+      # endpoints: []
+        ## Name of the endpoint's service port
+        ## Mutually exclusive with targetPort
+        # - port: ""
+
+        ## Name or number of the endpoint's target port
+        ## Mutually exclusive with port
+        # - targetPort: ""
+
+        ## File containing bearer token to be used when scraping targets
+        ##
+        #   bearerTokenFile: ""
+
+        ## Interval at which metrics should be scraped
+        ##
+        #   interval: 30s
+
+        ## HTTP path to scrape for metrics
+        ##
+        #   path: /metrics
+
+        ## HTTP scheme to use for scraping
+        ##
+        #   scheme: http
+
+        ## TLS configuration to use when scraping the endpoint
+        ##
+        #   tlsConfig:
+
+            ## Path to the CA file
+            ##
+            # caFile: ""
+
+            ## Path to client certificate file
+            ##
+            # certFile: ""
+
+            ## Skip certificate verification
+            ##
+            # insecureSkipVerify: false
+
+            ## Path to client key file
+            ##
+            # keyFile: ""
+
+            ## Server name used to verify host name
+            ##
+            # serverName: ""
+
+  ## Prometheus StorageSpec for persistent data
+  ## Ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/user-guides/storage.md
+  ##
+  storageSpec:
+    volumeClaimTemplate:
+      metadata:
+        name: prometheus-metrics
+        annotations:
+          "helm.sh/resource-policy": keep
+      spec:
+        storageClassName: fast
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 100Gi
+      #selector: {}
+
+# default rules are in templates/general.rules.yaml
+# prometheusRules: {}
+
+
+# Select Deployed DNS Solution
+deployCoreDNS: false
+deployKubeDNS: true
+deployKubeEtcd: true
+
+##Custom Labels to be added to Prometheus Rules CRD
+##
+additionalRulesLabels: 
+  role: alert-rules
+  prometheus: monitoring-kube-prometheus

--- a/samples/config/prometheus-values/shared-cluster.yaml
+++ b/samples/config/prometheus-values/shared-cluster.yaml
@@ -1,0 +1,474 @@
+# exporter-node configuration
+deployExporterNode: True
+
+# set https to false for GKE. True by default for minikube
+exporter-kubelets:
+  https: false
+
+# Grafana
+deployGrafana: True
+
+# Kube-scheduler
+deployKubeScheduler: False
+
+# Controller Manager
+deployKubeControllerManager: False
+
+# Kube state
+deployKubeState: True
+
+## If true, create & use RBAC resources resp. Pod Security Policies
+##
+global:
+  rbacEnable: true
+  pspEnable: true
+
+# AlertManager
+deployAlertManager: True
+
+alertmanager:
+  ## Alertmanager configuration directives
+  ## Ref: https://prometheus.io/docs/alerting/configuration/
+  ##
+  config:
+    global:
+      resolve_timeout: 5m
+      slack_api_url: 'https://hooks.slack.com/services/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'
+    route:
+      group_by: [alertname]
+      group_wait: 30s
+      group_interval: 5m
+      repeat_interval: 4h
+      # All alerts to go to slack unless matched below
+      receiver: 'slack-notifications'
+      routes:
+      # Send non required alerts to null receiver
+      - match:
+          alertname: K8SControllerManagerDown
+        receiver: 'null'
+      - match:
+          alertname: K8SSchedulerDown
+        receiver: 'null'
+      
+    receivers:
+    - name: 'null'
+    - name: 'slack-notifications'
+      slack_configs:
+      - channel: '#alerts-shared-cluster'
+        text: "Summary: {{ .CommonAnnotations.summary }}\nDescription: {{ .CommonAnnotations.description }}"
+       
+
+  ## External URL at which Alertmanager will be reachable
+  ##
+  externalUrl: ""
+
+  ## Alertmanager container image
+  ##
+  image:
+    repository: quay.io/prometheus/alertmanager
+    tag: v0.14.0
+
+  ingress:
+    ## If true, Alertmanager Ingress will be created
+    ##
+    enabled: false
+
+    ## Annotations for Alertmanager Ingress
+    ##
+    annotations: {}
+      # kubernetes.io/ingress.class: nginx
+      # kubernetes.io/tls-acme: "true"
+
+    ## Labels to be added to the Ingress
+    ##
+    labels: {}
+
+    ## Hostnames.
+    ## Must be provided if Ingress is enabled.
+    ##
+    # hosts:
+    #   - alertmanager.domain.com
+    hosts: []
+
+    ## TLS configuration for Alertmanager Ingress
+    ## Secret must be manually created in the namespace
+    ##
+    tls: []
+      # - secretName: alertmanager-general-tls
+      #   hosts:
+      #     - alertmanager.example.com
+
+  ## Node labels for Alertmanager pod assignment
+  ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+
+  ## If true, the Operator won't process any Alertmanager configuration changes
+  ##
+  paused: false
+
+  ## Number of Alertmanager replicas desired
+  ##
+  replicaCount: 1
+
+  ## Pod anti-affinity can prevent the scheduler from placing Alertmanager replicas on the same node.
+  ## The default value "soft" means that the scheduler should *prefer* to not schedule two replica pods onto the same node but no guarantee is provided.
+  ## The value "hard" means that the scheduler is *required* to not schedule two replica pods onto the same node.
+  ## The value "" will disable pod anti-affinity so that no anti-affinity rules will be configured.
+  podAntiAffinity: "soft"
+
+  ## Resource limits & requests
+  ## Ref: https://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  resources: {}
+    # requests:
+    #   memory: 400Mi
+
+  ## List of Secrets in the same namespace as the AlertManager
+  ## object, which shall be mounted into the AlertManager Pods.
+  ## Ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#alertmanagerspec
+  ##
+  secrets: []
+
+  service:
+    ## Annotations to be added to the Service
+    ##
+    annotations: {}
+
+    ## Cluster-internal IP address for Alertmanager Service
+    ##
+    clusterIP: ""
+
+    ## List of external IP addresses at which the Alertmanager Service will be available
+    ##
+    externalIPs: []
+
+    ## External IP address to assign to Alertmanager Service
+    ## Only used if service.type is 'LoadBalancer' and supported by cloud provider
+    ##
+    loadBalancerIP: ""
+
+    ## List of client IPs allowed to access Alertmanager Service
+    ## Only used if service.type is 'LoadBalancer' and supported by cloud provider
+    ##
+    loadBalancerSourceRanges: []
+
+    ## Port to expose on each node
+    ## Only used if service.type is 'NodePort'
+    ##
+    nodePort: 30903
+
+    ## Service type
+    ##
+    type: ClusterIP
+
+  ## Alertmanager StorageSpec for persistent data
+  ## Ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/user-guides/storage.md
+  ##
+  storageSpec: {}
+  #  volumeClaimTemplate:
+  #    spec:
+  #      storageClassName: gluster
+  #      accessModes: ["ReadWriteOnce"]
+  #      resources:
+  #        requests:
+  #          storage: 50Gi
+  #    selector: {}
+
+prometheus:
+  ## Alertmanagers to which alerts will be sent
+  ## Ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#alertmanagerendpoints
+  ##
+  alertingEndpoints: []
+  #   - name: ""
+  #     namespace: ""
+  #     port: 9093
+  #     scheme: http
+
+  ## Prometheus configuration directives
+  ## Ignored if serviceMonitors are defined
+  ## Ref: https://prometheus.io/docs/operating/configuration/
+  ##
+  config:
+    specifiedInValues: true
+    value: {}
+
+  ## External URL at which Prometheus will be reachable
+  ##
+  externalUrl: ""
+
+  ## Prometheus container image
+  ##
+  image:
+    repository: quay.io/prometheus/prometheus
+    tag: v2.2.1
+
+  ingress:
+    ## If true, Prometheus Ingress will be created
+    ##
+    enabled: false
+
+    ## Annotations for Prometheus Ingress
+    ##
+    annotations: {}
+      # kubernetes.io/ingress.class: nginx
+      # kubernetes.io/tls-acme: "true"
+
+    ## Labels to be added to the Ingress
+    ##
+    labels: {}
+
+    ## Hostnames.
+    ## Must be provided if Ingress is enabled.
+    ##
+    # hosts:
+    #   - alertmanager.domain.com
+    hosts: []
+
+    ## TLS configuration for Prometheus Ingress
+    ## Secret must be manually created in the namespace
+    ##
+    tls: []
+      # - secretName: prometheus-k8s-tls
+      #   hosts:
+      #     - prometheus.example.com
+
+  ## Node labels for Prometheus pod assignment
+  ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+
+  ## If true, the Operator won't process any Prometheus configuration changes
+  ##
+  paused: false
+
+  ## Number of Prometheus replicas desired
+  ##
+  replicaCount: 1
+
+  ## Pod anti-affinity can prevent the scheduler from placing Prometheus replicas on the same node.
+  ## The default value "soft" means that the scheduler should *prefer* to not schedule two replica pods onto the same node but no guarantee is provided.
+  ## The value "hard" means that the scheduler is *required* to not schedule two replica pods onto the same node.
+  ## The value "" will disable pod anti-affinity so that no anti-affinity rules will be configured.
+  podAntiAffinity: "soft"
+
+  ## Resource limits & requests
+  ## Ref: https://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  resources: {}
+    # requests:
+    #   memory: 400Mi
+
+  ## List of Secrets in the same namespace as the Prometheus
+  ## object, which shall be mounted into the Prometheus Pods.
+  ## Ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec
+  ##
+  secrets: []
+
+  ## How long to retain metrics
+  ##
+  retention: 30d
+
+  ## Prefix used to register routes, overriding externalUrl route.
+  ## Useful for proxies that rewrite URLs.
+  ##
+  routePrefix: /
+
+  ## Rules configmap selector
+  ## Ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/design.md
+  ##
+  ## 1. If `matchLabels` is used, `rules.additionalLabels` must contain all the labels from
+  ##    `matchLabels` in order to be be matched by Prometheus
+  ## 2. If `matchExpressions` is used `rules.additionalLabels` must contain at least one label
+  ##    from `matchExpressions` in order to be matched by Prometheus
+  ## Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
+  #rulesSelector: {}
+   #rulesSelector: {
+   #   matchExpressions: [{key: prometheus, operator: In, values: [example-rules, example-rules-2]}]
+   # }
+   ### OR
+  #rulesSelector:
+  #  matchLabels: 
+  #    role: alert-rules
+  #    prometheus: monitoring-kube-prometheus
+
+
+  ## Prometheus alerting & recording rules
+  ## Ref: https://prometheus.io/docs/querying/rules/
+  ## Ref: https://prometheus.io/docs/alerting/rules/
+  ##
+  rules:
+    specifiedInValues: true
+    ## What additional rules to be added to the ConfigMap
+    ## You can use this together with `rulesSelector`
+    additionalLabels:
+      role: alert-rules
+      prometheus: monitoring-kube-prometheus
+    value: {}
+
+  service:
+    ## Annotations to be added to the Service
+    ##
+    annotations: {}
+
+    ## Cluster-internal IP address for Prometheus Service
+    ##
+    clusterIP: ""
+
+    ## List of external IP addresses at which the Prometheus Service will be available
+    ##
+    externalIPs: []
+
+    ## External IP address to assign to Prometheus Service
+    ## Only used if service.type is 'LoadBalancer' and supported by cloud provider
+    ##
+    loadBalancerIP: ""
+
+    ## List of client IPs allowed to access Prometheus Service
+    ## Only used if service.type is 'LoadBalancer' and supported by cloud provider
+    ##
+    loadBalancerSourceRanges: []
+
+    ## Port to expose on each node
+    ## Only used if service.type is 'NodePort'
+    ##
+    nodePort: 30900
+
+    ## Service type
+    ##
+    type: ClusterIP
+
+  ## Service monitors selector
+  ## Ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/design.md
+  ##
+  serviceMonitorsSelector:
+    matchExpressions:
+    - key: app
+      operator: In
+      values:
+      - alertmanager
+      - exporter-coredns
+      - exporter-kube-dns
+      - exporter-kube-etcd
+      - exporter-kube-state
+      - exporter-kubelets
+      - exporter-kubernetes
+      - exporter-node
+      - grafana
+      - prometheus
+      - prometheus-operator
+      - am
+      - ds
+      - idm
+      - ig
+
+  ## ServiceMonitor CRDs to create & be scraped by the Prometheus instance.
+  ## Ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/service-monitor.md
+  ##
+  serviceMonitors: []
+    ## Name of the ServiceMonitor to create
+    ##
+    # - name: ""
+
+      ## Service label for use in assembling a job name of the form <label value>-<port>
+      ## If no label is specified, the service name is used.
+      ##
+      # jobLabel: ""
+
+      ## Label selector for services to which this ServiceMonitor applies
+      ##
+      # selector: {}
+
+      ## Namespaces from which services are selected
+      ##
+      # namespaceSelector:
+        ## Match any namespace
+        ##
+        # any: false
+
+        ## Explicit list of namespace names to select
+        ##
+        # matchNames: []
+
+      ## Endpoints of the selected service to be monitored
+      ##
+      # endpoints: []
+        ## Name of the endpoint's service port
+        ## Mutually exclusive with targetPort
+        # - port: ""
+
+        ## Name or number of the endpoint's target port
+        ## Mutually exclusive with port
+        # - targetPort: ""
+
+        ## File containing bearer token to be used when scraping targets
+        ##
+        #   bearerTokenFile: ""
+
+        ## Interval at which metrics should be scraped
+        ##
+        #   interval: 30s
+
+        ## HTTP path to scrape for metrics
+        ##
+        #   path: /metrics
+
+        ## HTTP scheme to use for scraping
+        ##
+        #   scheme: http
+
+        ## TLS configuration to use when scraping the endpoint
+        ##
+        #   tlsConfig:
+
+            ## Path to the CA file
+            ##
+            # caFile: ""
+
+            ## Path to client certificate file
+            ##
+            # certFile: ""
+
+            ## Skip certificate verification
+            ##
+            # insecureSkipVerify: false
+
+            ## Path to client key file
+            ##
+            # keyFile: ""
+
+            ## Server name used to verify host name
+            ##
+            # serverName: ""
+
+  ## Prometheus StorageSpec for persistent data
+  ## Ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/user-guides/storage.md
+  ##
+  storageSpec:
+    volumeClaimTemplate:
+      metadata:
+        name: prometheus-metrics
+        annotations:
+          "helm.sh/resource-policy": keep
+      spec:
+        storageClassName: fast
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 100Gi
+      #selector: {}
+
+# default rules are in templates/general.rules.yaml
+# prometheusRules: {}
+
+
+# Select Deployed DNS Solution
+deployCoreDNS: false
+deployKubeDNS: true
+deployKubeEtcd: true
+
+##Custom Labels to be added to Prometheus Rules CRD
+##
+additionalRulesLabels: 
+  role: alert-rules
+  prometheus: monitoring-kube-prometheus


### PR DESCRIPTION
Removed notifications from the default alertmanager configuration.

Added sample cluster specific configuration files to the samples/prometheus-values/ folder with notifications configured.(improving notifications will be added as part of a different ticket).

Updated the Prometheus readme in helm/forgerock-metrics/.

@David - need to discuss required amendments to the Prometheus documentation. Can discuss later.