### PR TITLE
saasadmin/restadmin inconsistent naming between uid and dn

### DIFF
--- a/docker/ds/bootstrap/ldif/userstore/03_add-identity-entries.ldif
+++ b/docker/ds/bootstrap/ldif/userstore/03_add-identity-entries.ldif
@@ -18,7 +18,7 @@ ds-privilege-name: subentry-write
 ds-privilege-name: update-schema
 ds-privilege-name: password-reset
 
-dn: uid=restadmin,ou=admins,@BASE_DN@
+dn: uid=saasadmin,ou=admins,@BASE_DN@
 objectclass: top
 objectclass: person
 objectclass: organizationalPerson


### PR DESCRIPTION
Noticed that the DN and UID values were different for the saasadmin account - I updated the DN to match the UID/CN/SN properties.