### PR TITLE
in /samples/fr-platform, changed helm release name in skaffold config…

### DIFF
--- a/samples/fr-platform/skaffold.yaml
+++ b/samples/fr-platform/skaffold.yaml
@@ -23,7 +23,7 @@ build:
 deploy:
   helm:
     releases:
-      - name: fr-sample-platform
+      - name: sample-fr-platform
         chartPath: .
         namespace: sample
         values:


### PR DESCRIPTION
… to be consistent with 'sample-fr-platform' used everywhere else, including README.md references