### PR TITLE
Parameterize additional credentials in IDM and Amster Helm Charts

### DIFF
--- a/helm/amster/templates/config-map.yaml
+++ b/helm/amster/templates/config-map.yaml
@@ -39,3 +39,4 @@ data:
   CTS_STORES: {{ default "ctsstore-0.ctsstore:1389" .Values.ctsStores }}
   CTS_PASSWORD: {{ default "password" .Values.ctsPassword }}
   FQDN: {{ template "fqdn" . }}
+  PROMETHEUS_PASSWORD: {{ .Values.prometheusPassword }}

--- a/helm/amster/values.yaml
+++ b/helm/amster/values.yaml
@@ -20,6 +20,7 @@ domain: .example.com
 amadminPassword: password
 encryptionKey: "123456789012"
 policyAgentPassword: Passw0rd
+prometheusPassword: prometheus
 
 
 config:

--- a/helm/openidm/templates/configmap.yaml
+++ b/helm/openidm/templates/configmap.yaml
@@ -59,9 +59,15 @@ data:
       openidm.keystore.password=changeit
       openidm.truststore.password=changeit
 
+      {{ if .Values.openidm.staticUser }}
+      # Optional static credentials for custom authentication.json use cases
+      openidm.staticUser.username={{ .Values.openidm.staticUser.username }}
+      openidm.staticUser.password={{ .Values.openidm.staticUser.password }}
+      {{ end }}
+
       # Prometheus endpoint authentication
-      openidm.prometheus.username=prometheus
-      openidm.prometheus.password=prometheus
+      openidm.prometheus.username={{ .Values.openidm.prometheus.username }}
+      openidm.prometheus.password={{ .Values.openidm.prometheus.password }}
       openidm.prometheus.role=openidm-prometheus
 
       # Optionally use the crypto bundle to obfuscate the password and set one of these:

--- a/helm/openidm/values.yaml
+++ b/helm/openidm/values.yaml
@@ -55,6 +55,9 @@ openidm:
   # Optional client secret for AM/IDM integration:
   idpconfig:
     clientsecret: password
+  prometheus:
+    username: prometheus
+    password: prometheus
 
 # Optional - if there is a DJ userstore configured
 userstore:


### PR DESCRIPTION
Parameterize Prometheus credentials in IDM and Amster Helm Charts, and add optional static user credentials for IDM