### PR TITLE
Add amadminPasswordHashed parameter to Amster Helm Chart

### DIFF
--- a/helm/amster/templates/config-map.yaml
+++ b/helm/amster/templates/config-map.yaml
@@ -39,4 +39,5 @@ data:
   CTS_STORES: {{ default "ctsstore-0.ctsstore:1389" .Values.ctsStores }}
   CTS_PASSWORD: {{ default "password" .Values.ctsPassword }}
   FQDN: {{ template "fqdn" . }}
-  PROMETHEUS_PASSWORD: {{ .Values.prometheusPassword }}
+  PROMETHEUS_PASSWORD: "{{ .Values.prometheusPassword }}"
+  AMADMIN_PASSWORD_HASHED: "{{ .Values.amadminPasswordHashed }}"

--- a/helm/amster/values.yaml
+++ b/helm/amster/values.yaml
@@ -18,6 +18,8 @@ domain: .example.com
 
 # Install passwords.
 amadminPassword: password
+# see AM Java source code org.forgerock.openam.shared.security.crypto.Hashes.secureHash(s)
+amadminPasswordHashed: "{SSHA-512}FBLj2oKbyR3ccq0Ydivp2PdsH5q7wbgh+UYwZdKjA6j0XB5Qu6wvzbMoCNyMRkAqsmu8E6rPIH2dUFuCPtiHBFAfdMsKvg/TBjTz+gQQU/g/NDgQRA=="
 encryptionKey: "123456789012"
 policyAgentPassword: Passw0rd
 prometheusPassword: prometheus


### PR DESCRIPTION
Add amadminPasswordHashed parameter to Amster Helm Chart. An example use (notice escaping the leading curly brace):

```
helm install helm/amster \
 --set \
image.repository=gcr.io/engineering-devops/amster,\
image.tag=6.5.0-M0,\
domain=.forgeblocks.com,\
config.importPath=/git/config/forgecloud/default/am,\
fqdn=openam.fr-travis-test.forgeblocks.com,\
amadminPasswordHashed="\\{SSHA-512}FBKZJNpElwzJ9/MSQ2oeIZTJSZNPgY7+L6NBr0Pf6rPClBbIRK+HdukeAkoNrhW26m6XOSD5H5M/kE/SMrv+U0mVbBx2MqkDfUuHkFwUnkdDNRGmEQ=="
```

NOTE: the default value is the hash for the default amAdmin password, which is "password"