### PR TITLE
postgres and version bumps

### DIFF
--- a/docker/openam/Dockerfile
+++ b/docker/openam/Dockerfile
@@ -4,7 +4,7 @@
 #
 FROM forgerock/downloader 
 
-ARG VERSION=" 6.5.0-M5"
+ARG VERSION="6.5.0-M6"
 RUN download -v $VERSION openam 
 RUN mkdir -p /var/tmp/openam && unzip -q /openam.war -d /var/tmp/openam
 

--- a/docker/openidm/Dockerfile
+++ b/docker/openidm/Dockerfile
@@ -2,8 +2,11 @@
 # Copyright (c) 2016-2017 ForgeRock AS.
 FROM forgerock/downloader 
 
-ARG VERSION="6.5.0-M2"
-RUN download -v $VERSION openidm 
+# ARG VERSION="6.5.0-M2"
+# RUN download -v $VERSION openidm 
+
+ARG VERSION="6.5.0"
+RUN download -s -v $VERSION openidm 
 RUN mkdir -p /var/tmp/openidm && unzip -q /openidm.zip -d /var/tmp && rm -fr /var/tmp/openidm/samples
 
 FROM forgerock/java:6.0.0

--- a/helm/postgres-openidm/templates/deployment.yaml
+++ b/helm/postgres-openidm/templates/deployment.yaml
@@ -81,7 +81,7 @@ spec:
         configMap:
           name: openidm-sql
       - name: data
-      {{- if .Values.persistence.enabled }}
+      {{- if .Values.persistence }}
         persistentVolumeClaim:
           # If you want to run multiple instances in the same namespace, uncomment below:
           #claimName: {{ template "fullname" . }}

--- a/helm/postgres-openidm/templates/pvc.yaml
+++ b/helm/postgres-openidm/templates/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.persistence.enabled }}
+{{- if .Values.persistence }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
@@ -10,12 +10,11 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-  annotations:
-    volume.alpha.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
 spec:
   accessModes:
-    - {{ .Values.persistence.accessMode | quote }}
+    - {{ .Values.accessMode | quote }}
+  storageClassName:  {{ .Values.storageClassName }}
   resources:
     requests:
-      storage: {{ .Values.persistence.size | quote }}
+      storage: {{ .Values.storageSize | quote }}
 {{- end }}

--- a/helm/postgres-openidm/values.yaml
+++ b/helm/postgres-openidm/values.yaml
@@ -1,8 +1,4 @@
 
-## postgres image version
-## ref: https://hub.docker.com/r/library/postgres/tags/
-##
-imageTag: "9.5.4"
 
 ## Specify a imagePullPolicy.
 ## 'Always' if imageTag is 'latest', else set to 'IfNotPresent'.
@@ -23,17 +19,18 @@ imageTag: "9.5.4"
 # For postgres we  use the standard vanilla image on the Docker hub.
 postgres:
   image: postgres
-  tag: 9-alpine
+  tag: 10.5-alpine
 
 postgresUser: openidm
 postgresPassword: openidm
 
-## Persist data to a persitent volume.
-persistence:
-  enabled: true
-  storageClass: generic
-  accessMode: ReadWriteOnce
-  size: 8Gi
+## Persist data
+persistence: true
+  
+accessMode: ReadWriteOnce
+storageClassName: standard
+storageSize: 8Gi
+
 
 # The metrics configuration has been taken from the master Helm postgres chart
 # This has not been tested.


### PR DESCRIPTION
Updated postgres helm chart to more current 10.5 release
Updated postgres chart for improved storage class handling
Update AM docker image to M6
Update OpenIDM image to use a snapshot until a new Milestone is produced