### PR TITLE
Switching to postgres as repo for testing and fine tuned resource limits

### DIFF
--- a/samples/config/prod/m-cluster/openidm.yaml
+++ b/samples/config/prod/m-cluster/openidm.yaml
@@ -1,7 +1,9 @@
 resources:
   limits:
+    cpu: 10000m
     memory: 6Gi
   requests:
+    cpu: 4000m
     memory: 4Gi
 
 # For JDK 8
@@ -23,3 +25,17 @@ config:
   name: frconfig
   path: /git/config/samples/idm/m-cluster
   strategy: git
+
+openidm:
+  repo:
+    host: postgresql
+    port: 5432
+    user: openidm
+    password: openidm
+    schema: openidm
+    #databaseName: openidm
+    # DS external repo
+    #host: userstore-0.userstore
+    #port: 1389
+    #user: "cn=Directory Manager"
+    #password: password


### PR DESCRIPTION
During recent load testing the CRUD TPS remained very low until i realized that there is a cpu limit in original values.yaml and i was only overriding memory.  Therefore i have added cpu override also and hence the TPS has gone up to satisfaction.