### PR TITLE
Add a uid index to idmRoot 

### DIFF
--- a/docker/ds/bootstrap/setup-ds.sh
+++ b/docker/ds/bootstrap/setup-ds.sh
@@ -74,6 +74,15 @@ echo "Creating CTS UID index for uid=monitor search"
           --index-name uid \
           --offline \
           --no-prompt
+echo "Creating UID index on idmRoot"
+./bin/dsconfig create-backend-index \
+          --backend-name idmRoot \
+          --set index-type:equality \
+          --type generic \
+          --index-name uid \
+          --offline \
+          --no-prompt
+
 
 
 echo "Tuning the disk free space thresholds"


### PR DESCRIPTION
so that uid=monitor and other searches with uid as filter are not unindexed