### PR TITLE
Adding "args" to the postgres section 

### DIFF
--- a/bin/create-cluster.sh
+++ b/bin/create-cluster.sh
@@ -72,7 +72,6 @@ gcloud container clusters create $GKE_CLUSTER_NAME \
       --labels="owner=sre" \
       --addons=HorizontalPodAutoscaling \
       --enable-autoscaling \
-      --enable-autoupgrade \
       --enable-autorepair \
       --scopes "https://www.googleapis.com/auth/cloud-platform" \
       --enable-cloud-logging \
@@ -83,5 +82,6 @@ gcloud container clusters create $GKE_CLUSTER_NAME \
 #  --enable-stackdriver-kubernetes
 #  --scopes "gke-default"
 #  --preemptible
+#  --enable-autoupgrade 
 
 

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -214,7 +214,7 @@ restart_am()
     echo "=> Deleting \"${OPENAM_POD_NAME}\" to restart and read newly imported configuration"
     kubectl delete pod $OPENAM_POD_NAME --namespace=${NAMESPACE}
     if [ $? -ne 0 ]; then
-        echo "Could not delete AM pod.  Please check error and fix"
+        echo "Could not delete AM pod.  Please check error and fix."
     fi
     sleep 10
     isalive_check
@@ -222,11 +222,21 @@ restart_am()
 
 scale_am()
 {
-    echo "=> Scaling AM to two replicas..."
+    echo "=> Scaling AM deployment..."
     DEPNAME=$(kubectl get deployment -l app=openam -o name)
     kubectl scale --replicas=2 ${DEPNAME} || true
     if [ $? -ne 0 ]; then
-        echo "Could not scale AM pod.  Please check error and fix" 
+        echo "Could not scale AM deployment.  Please check error and fix."
+    fi
+}
+
+scale_idm()
+{
+    echo "=> Scaling IDM deployment..."
+    DEPNAME=$(kubectl get deployment -l app=openidm -o name)
+    kubectl scale --replicas=2 ${DEPNAME} || true
+    if [ $? -ne 0 ]; then
+        echo "Could not scale IDM deployment.  Please check error and fix."
     fi
 }
 
@@ -235,7 +245,7 @@ deploy_hpa()
     echo "=> Deploying Horizontal Autoscale Chart..."
     kubectl apply -f ${CFGDIR}/hpa.yaml || true
     if [ $? -ne 0 ]; then
-        echo "Could not deploy HPA.  Please check error and fix" 
+        echo "Could not deploy HPA.  Please check error and fix."
     fi
 }
 
@@ -275,6 +285,7 @@ fi
 # Do not scale or deploy hpa on minikube
 if [ "${CONTEXT}" != "minikube" ]; then
     scale_am
+    scale_idm
     #deploy_hpa # TODO
 fi
 

--- a/docker/ds/bootstrap/setup-idm.sh
+++ b/docker/ds/bootstrap/setup-idm.sh
@@ -91,7 +91,19 @@ for idx in ${INDEX[@]}; do
     --no-prompt
 done
 
+# userRoot also needs few of the above indexes if and when it is used
+# in explicit mapping for idm
+INDEX=(fr-idm-json fr-idm-managed-user-json fr-idm-managed-role-json)
 
+for idx in ${INDEX[@]}; do
+  ./bin/dsconfig \
+    create-backend-index \
+    --backend-name userRoot \
+    --index-name ${idx} \
+    --set index-type:equality \
+    --offline \
+    --no-prompt
+done
 
 # vlvs for admin UI usage
 

--- a/helm/openidm/templates/deployment.yaml
+++ b/helm/openidm/templates/deployment.yaml
@@ -4,6 +4,7 @@ kind: Deployment
 metadata:
   name: {{ template "fullname" . }}
   labels:
+    app: {{ template "name" . }}
     component: {{ .Values.component }}
     vendor: forgerock
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}

--- a/helm/postgres-openidm/templates/deployment.yaml
+++ b/helm/postgres-openidm/templates/deployment.yaml
@@ -41,6 +41,8 @@ spec:
             secretKeyRef:
               name: {{ template "name" . }}
               key: postgres-password
+        # Adding the default values here just to provide a place to tune further
+        args: ['-c','shared_buffers=128MB','-c','max_connections=100']
         ports:
         - name: postgresql
           containerPort: 5432


### PR DESCRIPTION
Any arguments to the postgres daemon can be added to this array.  Right now it is exposing two args which can be used to tune the shared_buffers and max_connections.  But any others can be added to this array.  Also the values of the two args is intentionally left at default as they are highly depending on the resources available and in a minimal minikube install we don't want to push the memory.