### PR TITLE
Gatling-benchmark chart jvm opts

### DIFF
--- a/helm/gatling-benchmark/templates/gatling.yaml
+++ b/helm/gatling-benchmark/templates/gatling.yaml
@@ -21,6 +21,7 @@ spec:
           - /bin/bash
           - -c
           - touch /ready && /custom-gatling.sh  -j '
+            {{ .Values.javaopts }}
             -Dam_host={{ .Values.benchmark.openam.host }}
             -Dam_port={{ .Values.benchmark.openam.port }}
             -Didm_host={{ .Values.benchmark.openidm.host }}
@@ -52,10 +53,7 @@ spec:
             - mountPath: /etc/nginx/conf.d
               name: nginx-conf-vol
           resources:
-      #resources:
-      #  requests:
-      #    cpu: 1000m
-      #    memory: 2048Mi
+{{ toYaml .Values.resources | indent 14 }}
       imagePullSecrets:
         - name: forgerock-engkube-pull-secret
       volumes:

--- a/helm/gatling-benchmark/values.yaml
+++ b/helm/gatling-benchmark/values.yaml
@@ -10,6 +10,17 @@ image:
   repository: gcr.io/engineering-devops/gatling:6.5.0
   pullPolicy: Always
 
+# Resources for gatling benchmark chart
+resources:
+  limits:
+    memory: 4096Mi
+  requests:
+    memory: 2048Mi
+
+# Gatling heap
+# Heap should be always max 75% of resource.limits.memory settings
+javaopts: -Xmx2G
+
 benchmark:
   # Name of scala test name to run
   # This benchmark supports following testnames


### PR DESCRIPTION
Adding couple of options how to control pod resources and jvm related settings. 