### PR TITLE
Removing legacy ingress annotations

### DIFF
--- a/helm/openam/values.yaml
+++ b/helm/openam/values.yaml
@@ -93,17 +93,11 @@ ingress:
   enabled: true
   annotations:
     kubernetes.io/ingress.class: nginx
-    # Do not use for nginx. TODO: Does warp need this?
-    #ingress.kubernetes.io/rewrite-target: /
-    ingress.kubernetes.io/enable-cors: "false"
-    ingress.kubernetes.io/affinity: "cookie"
-    ingress.kubernetes.io/session-cookie-name: "route"
-    ingress.kubernetes.io/session-cookie-hash: "sha1"
-    ingress.kubernetes.io/ssl-redirect: "true"
-    # Nginx specific annotations
     nginx.ingress.kubernetes.io/affinity: "cookie"
     nginx.ingress.kubernetes.io/session-cookie-name: "route"
     nginx.ingress.kubernetes.io/session-cookie-hash: "sha1"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/enable-cors: "false"
     
 # Audit log details for log streaming sidecar containers
 

--- a/helm/openidm/values.yaml
+++ b/helm/openidm/values.yaml
@@ -93,7 +93,7 @@ ingress:
     nginx.ingress.kubernetes.io/affinity: "cookie"
     nginx.ingress.kubernetes.io/session-cookie-name: "route"
     nginx.ingress.kubernetes.io/session-cookie-hash: "sha1"
-    ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
 
 # Audit log details for log streaming sidecar containers
 

--- a/helm/openig/values.yaml
+++ b/helm/openig/values.yaml
@@ -57,17 +57,11 @@ ingress:
   enabled: true
   annotations:
     kubernetes.io/ingress.class: nginx
-    # Do not use for nginx. TODO: Does warp need this?
-    #ingress.kubernetes.io/rewrite-target: /
-    ingress.kubernetes.io/enable-cors: "false"
-    ingress.kubernetes.io/affinity: "cookie"
-    ingress.kubernetes.io/session-cookie-name: "route"
-    ingress.kubernetes.io/session-cookie-hash: "sha1"
-    ingress.kubernetes.io/ssl-redirect: "true"
-    # Nginx specific annotations
     nginx.ingress.kubernetes.io/affinity: "cookie"
     nginx.ingress.kubernetes.io/session-cookie-name: "route"
     nginx.ingress.kubernetes.io/session-cookie-hash: "sha1"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/enable-cors: "false"
     
 # Audit log details for log streaming sidecar containers
 


### PR DESCRIPTION
For the nginx ingress, removing and converting any annotations that start with "ingress.kubernetes.io" to "nginx.ingress.kubernetes.io"