### PR TITLE
Changing git paths after refactor of forgeops-init

### DIFF
--- a/samples/config/prod/m-cluster/amster.yaml
+++ b/samples/config/prod/m-cluster/amster.yaml
@@ -1,6 +1,5 @@
 config:
-  #importPath: /git/config/samples/am/R6.0
-  importPath: /git/config/samples/am/m-cluster
+  importPath: /git/config/6.0/m-cluster/am
   exportPath: /tmp/amster
 
 version: 6.5.0-M0

--- a/samples/config/prod/m-cluster/ctsstore.yaml
+++ b/samples/config/prod/m-cluster/ctsstore.yaml
@@ -12,15 +12,15 @@ storageSize: 500Gi
 storageClass: fast
 
 # For JDK 8
-# opendjJavaArgs: >
-#   -server -Xms10g -Xmx10g -XX:+UseCompressedOops -XX:+UseG1GC -XX:+UseNUMA 
-#   -XX:MaxGCPauseMillis=100 -verbose:gc -XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps 
-#   -XX:+PrintGCDetails -XX:+PrintPromotionFailure -XX:+PrintAdaptiveSizePolicy -Xloggc:/tmp/gc.log
+opendjJavaArgs: >
+   -server -Xms10g -Xmx10g -XX:+UseCompressedOops -XX:+UseG1GC -XX:+UseNUMA 
+   -XX:MaxGCPauseMillis=100 -verbose:gc -XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps 
+   -XX:+PrintGCDetails -XX:+PrintPromotionFailure -XX:+PrintAdaptiveSizePolicy -Xloggc:/tmp/gc.log
 
 # For JDK 11
-opendjJavaArgs: >
- -server -Xms10g -Xmx10g -XX:+UseCompressedOops -XX:+UseG1GC -XX:+UseNUMA  
- -XX:MaxGCPauseMillis=100 -verbose:gc -Xlog:gc:/tmp/gc.log
+#opendjJavaArgs: >
+# -server -Xms10g -Xmx10g -XX:+UseCompressedOops -XX:+UseG1GC -XX:+UseNUMA  
+# -XX:MaxGCPauseMillis=100 -verbose:gc -Xlog:gc:/tmp/gc.log
 
 podAntiAffinity: hard
 

--- a/samples/config/prod/m-cluster/env.sh
+++ b/samples/config/prod/m-cluster/env.sh
@@ -30,4 +30,4 @@ DOMAIN="${DOMAIN/\./}"
 # The components to deploy
 # Note the opendj stores are aliased as configstore, 
 # userstore, ctstore - but they all use the opendj chart
-COMPONENTS=(frconfig dsadmin configstore userstore ctsstore openam amster openidm)
+COMPONENTS=(frconfig dsadmin configstore userstore ctsstore openam amster postgres-openidm openidm)

--- a/samples/config/prod/m-cluster/openidm.yaml
+++ b/samples/config/prod/m-cluster/openidm.yaml
@@ -23,7 +23,8 @@ replicaCount: 1
 
 config:
   name: frconfig
-  path: /git/config/samples/idm/m-cluster
+  #path: /git/config/6.5/m-cluster/idm/ds-repo-explicit
+  path: /git/config/6.5/default/idm/sync-with-ldap-bidirectional
   strategy: git
 
 openidm:
@@ -33,7 +34,7 @@ openidm:
     user: openidm
     password: openidm
     schema: openidm
-    #databaseName: openidm
+    databaseName: openidm
     # DS external repo
     #host: userstore-0.userstore
     #port: 1389

--- a/samples/config/prod/s-cluster/amster.yaml
+++ b/samples/config/prod/s-cluster/amster.yaml
@@ -1,6 +1,5 @@
 config:
-  #importPath: /git/config/samples/am/R6.0
-  importPath: /git/config/samples/am/m-cluster
+  importPath: /git/config/6.0/m-cluster/am
   exportPath: /tmp/amster
 
 version: 6.5.0-M0

--- a/samples/config/prod/s-cluster/openidm.yaml
+++ b/samples/config/prod/s-cluster/openidm.yaml
@@ -14,5 +14,6 @@ replicaCount: 1
 
 config:
   name: frconfig
-  path: /git/config/samples/idm/m-cluster
+  #path: /git/config/6.5/m-cluster/idm/ds-repo-explicit
+  path: /git/config/6.5/default/idm/sync-with-ldap-bidirectional
   strategy: git


### PR DESCRIPTION
After refactoring forgeops-init directory structure, various paths are fixed so that configuration files from GIT can be mounted correctly