### PR TITLE
removed up checks from alerts

### DIFF
--- a/samples/config/prometheus-values/shared-cluster.yaml
+++ b/samples/config/prometheus-values/shared-cluster.yaml
@@ -44,6 +44,7 @@ alertmanager:
       routes: 
       - match:
           alertname: DeadMansSwitch
+          alertname: up
         receiver: 'null'
       
     receivers:


### PR DESCRIPTION
Removed the up alerts for the shared-cluster config only as there is too much noise in Slack.