### PR TITLE
Modified amster version parameter behaviour

### DIFF
--- a/docker/amster/amster-install.sh
+++ b/docker/amster/amster-install.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 # Full amster install.
 
 
@@ -66,6 +66,12 @@ echo "Waiting for AM server at ${CONFIG_URL} "
 
 wait_for_openam
 
+# Extract amster version for commons parameter to modify configs
+echo "Extracting amster version"
+VER=$(./amster --version)
+[[ "$VER" =~ ([0-9].[0-9].[0-9]-([a-zA-Z][0-9]+|SNAPSHOT|RC[0-9]+)|[0-9].[0-9].[0-9]) ]]
+export VERSION=${BASH_REMATCH[1]}
+echo "Amster version is: " $VERSION
 
 # Execute Amster if the configuration is found.
 if [ -d  ${AMSTER_SCRIPTS} ]; then

--- a/helm/amster/templates/config-map.yaml
+++ b/helm/amster/templates/config-map.yaml
@@ -35,7 +35,6 @@ metadata:
 data:
   EXPORT_PATH: {{  default .Values.config.importPath .Values.config.exportPath }}
   CONFIG_PATH: "{{ .Values.config.importPath }}"
-  VERSION: {{ .Values.version }}
   CTS_STORES: {{ default "ctsstore-0.ctsstore:1389" .Values.ctsStores }}
   CTS_PASSWORD: {{ default "password" .Values.ctsPassword }}
   FQDN: {{ template "fqdn" . }}

--- a/helm/amster/values.yaml
+++ b/helm/amster/values.yaml
@@ -13,7 +13,7 @@ component: amster
 serverBase: http://openam:80
 
 
-# The top level domain (including the leading .). This excludes the openam component. 
+# The top level domain (including the leading .). This excludes the openam component.
 domain: .forgeops.com
 
 # Install passwords.
@@ -78,16 +78,12 @@ resources:
 
 # Optional value overrides
 
-# version. This sets the environment variable VERSION which is used by amster / commons config to
-# mass update the amster version tag on import. The amster configuration contains &{version} (see forgeops-init)
-version: 6.0.0
-
 # fqdn - the openam server external fqdn.
 # If this is *not* set, it defaults to openam.{namespace}{{ .Values.domain }}
 #fqdn: openam.acme.com
 
 # ctsStores - is a csv separated list of avaiable cts servers. This is referenced in the amster configuration as &{ctsStores} on
-# import. 
+# import.
 #ctsStores: ctsstore-0.ctsstore:1389
 
 # ctsPassword - defaults to "password"


### PR DESCRIPTION
Before: 
VERSION parameter was passed from helm chart. This would introduce import failures that might be hard to spot sometimes

Now: 
VERSION parameter is extracted from ./amster --version as part of amster-install.sh script

Supports following versions: x.x.x, x.x.x-RCx/Mx/SNAPSHOT