### PR TITLE
Updated postgres-openidm chart 

### DIFF
--- a/helm/openidm/values.yaml
+++ b/helm/openidm/values.yaml
@@ -36,7 +36,7 @@ javaOpts: "-Xmx1024m -server -XX:+UseG1GC"
 
 # To enable any of the products to use HTTPS on their external endpoint, set the following flag to true.
 useTLS: false
-# The default behaviour when useTLS = true, is to have cert-manager to manage the certificate request/renewal via Let's Encrypt.  
+# The default behaviour when useTLS = true, is to have cert-manager to manage the certificate request/renewal via Let's Encrypt.
 # This is enabled by the following flag:
 useCertManager: true
 
@@ -44,17 +44,17 @@ useCertManager: true
 openidm:
   repo:
     # DS external repo
-    host: userstore-0.userstore
-    port: 1389
-    user: "cn=Directory Manager"
-    password: password
+    # host: userstore-0.userstore
+    # port: 1389
+    # user: "cn=Directory Manager"
+    # password: password
     # postgres values
-    # host: postgresql
-    # port: 5432
-    # user: openidm
-    # password: openidm
-    # schema: openidm
-    # databaseName: openidm
+     host: postgresql
+     port: 5432
+     user: openidm
+     password: openidm
+     schema: openidm
+     databaseName: openidm
   # Optional client secret for AM/IDM integration:
   idpconfig:
     clientsecret: password

--- a/helm/postgres-openidm/sql/02_default_schema_optimization.sql
+++ b/helm/postgres-openidm/sql/02_default_schema_optimization.sql
@@ -43,4 +43,3 @@ CREATE INDEX idx_json_managedobjects_mail_gin ON openidm.managedobjects
   USING gin (json_extract_path_text(fullobject, 'mail') gin_trgm_ops);
 CREATE INDEX idx_json_managedobjects_accountStatus_gin ON openidm.managedobjects
   USING gin (json_extract_path_text(fullobject, 'accountStatus') gin_trgm_ops);
-


### PR DESCRIPTION
We had outdated scripts in postgres charts. Got a new ones from M2 release and tested it. Seems to work fine with new configs for smoke tests. 

Changes: 
- default repo values are now back to postgres
- updated scripts for postgres with new ones