### PR TITLE
comments / AM bump / java version

### DIFF
--- a/docker/csv/dev.csv
+++ b/docker/csv/dev.csv
@@ -1,7 +1,7 @@
 java,6.5.0
-ds,6.5.0-M127.1,latest
-openam,6.5.0-M5,latest
-amster,6.5.0-M5,latest
+ds,6.5.0-M128.1,latest
+openam,6.5.0-M7,latest
+amster,6.5.0-M7,latest
 openidm,6.5.0-M2,latest
 openig,6.5.0-M134,latest
 git,6.5.0

--- a/docker/java/Dockerfile
+++ b/docker/java/Dockerfile
@@ -4,7 +4,7 @@
 #
 # Copyright (c) 2016-2018 ForgeRock AS.
 
-FROM openjdk:8u151-jdk-alpine
+FROM openjdk:8-jdk-alpine
 
 ENV FORGEROCK_HOME /opt/forgerock
 

--- a/helm/openam/values.yaml
+++ b/helm/openam/values.yaml
@@ -73,8 +73,7 @@ openamHome: /home/forgerock/openam
 createBootstrap: true
 
 # This is an optional path to a script to execute before AM starts up. It can copy in images, update the web.xml, etc.
-# The path is *relative* to /git/config/{{ configPath.am }}.
-# For example:   /git/config/6.5/my-config/am/customize-am.sh
+# If you change set it to the full path to your cloned configuration.  Example: /git/config/default/6.5/my-openam/custom.sh
 amCustomizationScriptPath: "customize-am.sh"
 
 # Liveness probe tuning - time in seconds


### PR DESCRIPTION
Update openam values.yaml comment to indicate custom script path is absolute
bump AM milestone
Use relaxed version on java image so we pick up the latest java when we build