### PR TITLE
Fixed self registration test

### DIFF
--- a/cicd/forgeops-tests/tests/smoke/idm/IDMSmoke.py
+++ b/cicd/forgeops-tests/tests/smoke/idm/IDMSmoke.py
@@ -125,7 +125,9 @@ class IDMSmoke(unittest.TestCase):
                    'Cache-Control': 'no-cache'}
         params = {'_action': 'submitRequirements'}
         resp = post(url=self.idmcfg.rest_selfreg_url, params=params, headers=headers, json=user_data)
-        print(resp.text)
+        token = resp.json()["token"]
+        user_data["token"] = token
+        resp = post(url=self.idmcfg.rest_selfreg_url, params=params, headers=headers, json=user_data)
         self.assertEqual(200, resp.status_code)
 
     def test_7_user_reset_pw(self):
@@ -158,6 +160,7 @@ class IDMSmoke(unittest.TestCase):
         }
 
         stage1 = s.post(self.idmcfg.rest_selfpwreset_url, headers=headers_init, params=params, json=payload1)
+        print(stage1.content)
         self.assertEqual(200, stage1.status_code, "Try to find user with query for pw reset")
 
         payload2 = {


### PR DESCRIPTION
We were missing one step for self registration that was now needed (Probably after version bump). This is now fixed.