### PR TITLE
Update helm charts to default to bintray for pulling images.

### DIFF
--- a/docker/csv/dev.csv
+++ b/docker/csv/dev.csv
@@ -2,7 +2,7 @@ java,6.5.0
 ds,6.5.0-M128.1,latest
 openam,6.5.0-M7,latest
 amster,6.5.0-M7,latest
-openidm,6.5.0-M2,latest
+openidm,6.5.0-M3,latest
 openig,6.5.0-M134,latest
 git,6.5.0
 nginx-agent,6.5.0

--- a/helm/amster/templates/amster.yaml
+++ b/helm/amster/templates/amster.yaml
@@ -24,7 +24,7 @@ spec:
       {{ if eq .Values.config.strategy "git" -}}  
       initContainers:
       - name: git-init
-        image: forgerock/git:6.0.0
+        image: forgerock-docker-public.bintray.io/forgerock/git:6.0.0
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         volumeMounts:
         - name: git
@@ -67,7 +67,7 @@ spec:
 {{ toYaml .Values.resources | indent 12 }}
       {{ if eq .Values.config.strategy "git" -}}  
       - name: git
-        image: forgerock/git:6.0.0
+        image: forgerock-docker-public.bintray.io/forgerock/git:6.0.0
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         volumeMounts:
         - name: git

--- a/helm/amster/values.yaml
+++ b/helm/amster/values.yaml
@@ -38,8 +38,8 @@ config:
   strategy: git
 
 image:
-  repository: gcr.io/engineering-devops/amster
-  tag: latest
+  repository: forgerock-docker-public.bintray.io/amster
+  tag: 6.5.0-M7
   pullPolicy: IfNotPresent
   #pullPolicy: Always
 

--- a/helm/apache-agent/values.yaml
+++ b/helm/apache-agent/values.yaml
@@ -7,7 +7,7 @@ component: apache-agent
 
 domain: .forgeops.com
 image:
-  repository: gcr.io/engineering-devops/apache-agent
+  repository: forgerock-docker-public.bintray.io/apache-agent
   tag: latest
   pullPolicy: Always
 # If you set this to true, you must have a TLS secret with the same name as the FQDN.

--- a/helm/ds/values.yaml
+++ b/helm/ds/values.yaml
@@ -31,9 +31,9 @@ cts:
   enabled: true
 
 image:
-  repository: gcr.io/engineering-devops/ds
+  repository: forgerock-docker-public.bintray.io/ds
   pullPolicy: IfNotPresent
-  tag: latest
+  tag: 6.5.0-M128.1
 
 # The number of instances in the StatefulSet. Each instance is a combined DS/RS pair.
 # You can not change this after installation.
@@ -50,7 +50,7 @@ storageSize: "10Gi"
 
 backup:
   # If true this will mount a PVC of the given storage class on /opt/opendj/bak/
-  enabled: true
+  enabled: false
   storageClass: "nfs"
   storageSize: "20Gi"
  

--- a/helm/dsadmin/values.yaml
+++ b/helm/dsadmin/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 component: ds
 
 image:
-  repository: gcr.io/engineering-devops/ds
+  repository: forgerock-docker-public.bintray.io/ds
   pullPolicy: IfNotPresent
   tag: latest
 

--- a/helm/gatling-benchmark/templates/gatling.yaml
+++ b/helm/gatling-benchmark/templates/gatling.yaml
@@ -16,7 +16,7 @@ spec:
       initContainers:
       {{ if eq .Values.config.strategy  "git" }}
       - name: git-init
-        image: forgerock/git:6.0.0
+        image: forgerock-docker-public.bintray.io/forgerock/git:6.0.0
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         volumeMounts:
         - name: git

--- a/helm/gatling-benchmark/values.yaml
+++ b/helm/gatling-benchmark/values.yaml
@@ -7,7 +7,7 @@ domain: .forgeops.com
 # Gatling image with tests.
 # Dockerfile for this image can be found in forgeops/docker/gatling
 image:
-  repository: gcr.io/engineering-devops/gatling:6.5.0
+  repository: forgerock-docker-public.bintray.io/gatling:6.5.0
   pullPolicy: Always
 
 benchmark:

--- a/helm/nginx-agent/values.yaml
+++ b/helm/nginx-agent/values.yaml
@@ -28,6 +28,6 @@ agent:
 component: nginx-agent
 
 image:
-  repository: gcr.io/engineering-devops
+  repository: forgerock-docker-public.bintray.io
   tag: latest
   pullPolicy: Always

--- a/helm/openam/templates/openam-deployment.yaml
+++ b/helm/openam/templates/openam-deployment.yaml
@@ -18,7 +18,7 @@ spec:
       initContainers:
        {{ if eq .Values.config.strategy  "git" }}
       - name: git-init
-        image: forgerock/git:6.0.0
+        image: forgerock-docker-public.bintray.io/forgerock/git:6.0.0
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         volumeMounts:
         - name: git
@@ -36,7 +36,7 @@ spec:
         args: [ "wait", "{{ .Values.configLdapHost }}", "{{ .Values.configLdapPort }}" ]
       # todo: pull the util image scripts into a generic alpine image. Use a configmap for the scripts
       - name: bootstrap
-        image: forgerock/util:6.0.0
+        image: forgerock-docker-public.bintray.io/forgerock/util:6.0.0
         imagePullPolicy:  {{ .Values.image.pullPolicy }}
         env:
         - name: BASE_DN

--- a/helm/openam/values.yaml
+++ b/helm/openam/values.yaml
@@ -5,7 +5,7 @@
 component: openam
 
 image:
-  repository: gcr.io/engineering-devops/openam
+  repository: forgerock-docker-public.bintray.io/openam
   tag: latest
   # For development we set this to Always to get the most current image:
   pullPolicy: IfNotPresent

--- a/helm/openidm/templates/_helpers.tpl
+++ b/helm/openidm/templates/_helpers.tpl
@@ -34,7 +34,7 @@ tls:
 {{- define "git-init" -}}
 {{ if eq .Values.config.strategy "git" }}
 - name: git-init
-  image: forgerock/git:6.0.0
+  image: forgerock-docker-public.bintray.io/forgerock/git:6.0.0
   imagePullPolicy: {{ .Values.image.pullPolicy }}
   volumeMounts:
   - name: git

--- a/helm/openidm/templates/deployment.yaml
+++ b/helm/openidm/templates/deployment.yaml
@@ -25,7 +25,7 @@ spec:
       {{ if eq .Values.config.strategy  "git" }}
       initContainers:
       - name: git-init
-        image: gcr.io/engineering-devops/git:6.5.0
+        image: forgerock-docker-public.bintray.io/git:6.5.0
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         volumeMounts:
         - name: git
@@ -91,7 +91,7 @@ spec:
           mountPath: /var/run/openidm/logging
       {{ if eq .Values.config.strategy  "git" }}
       - name: git
-        image: forgerock/git:6.0.0
+        image: forgerock-docker-public.bintray.io/forgerock/git:6.0.0
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         volumeMounts:
         - name: git

--- a/helm/openidm/values.yaml
+++ b/helm/openidm/values.yaml
@@ -25,8 +25,8 @@ config:
 component: openidm
 
 image:
-  repository: gcr.io/engineering-devops/openidm
-  tag: latest
+  repository: forgerock-docker-public.bintray.io/openidm
+  tag: 6.5.0-M3
   pullPolicy: IfNotPresent
   # For development use Always
   # pullPolicy: Always

--- a/helm/openig/templates/deployment.yaml
+++ b/helm/openig/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
       {{ if eq .Values.config.strategy  "git" }}
       initContainers:
       - name: git-init
-        image: forgerock/git:6.0.0
+        image: forgerock-docker-public.bintray.io/forgerock/git:6.0.0
         volumeMounts:
         - name: git
           mountPath: /git

--- a/helm/openig/values.yaml
+++ b/helm/openig/values.yaml
@@ -31,8 +31,8 @@ useTLS: false
 useCertManager: true
 
 image:
-  repository: gcr.io/engineering-devops/openig
-  tag: latest
+  repository: forgerock-docker-public.bintray.io/openig
+  tag: 6.5.0-M134
   pullPolicy: IfNotPresent
 
 resources:


### PR DESCRIPTION
Allows better sync with EKS / GKE
Update helm charts with current stable milestones for each binary
update docker/ds/dev.csv with stable product milestones