### PR TITLE
Cloud 724 - combined current tls settings into a single setting.

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -96,18 +96,17 @@ Note that the details of the ingress will depend on the implementation. You may 
  
 # TLS
 
-To enable any of the products to use HTTPS on their external endpoint, set the following flag to true in your custom.yaml file.
-```
-useTLS: True
-```
+There is a single setting which controls the TLS strategy for your deployment: ```tlsStrategy: <value>```.   The values are as follows:
+* http  - no tls set. Using http only (unencrypted). This is the default setting.
+* https - tls enabled.  Provide own certificates.
+* https-cert-manager - tls enabled. Uses cert-Mmanager to automatically configure your certificate.
 
-The default behaviour when useTLS = true, is to have cert-manager to manage the certificate request/renewal via Let's Encrypt.  This is enabled by the following flag:
-```
-useCertManager: True
-```
+If ```tlsStrategy: https-cert-manager```, then the cert-manager deployment, which is deployed automatically as part of the bin/gke-ups.sh script, manages certificate request/renewal via Let's Encrypt. 
 
 If you want to use TLS but don't want cert-manager to manage the certificate request/renewal, then set
-useTLS to true, set useCertManager to false, and run the script ../bin/generate-tls.sh.
+```tlsStrategy: https```.  To use a self-signed certificate you can run the script ../bin/generate-tls.sh prior to deploying the helm chart.  This will automatically generate a self-signed certificate and deploy it into your namespace. Or you can provide your own.
+
+For further information on the above options, see the [DevOps developers guide](https://ea.forgerock.com/docs/platform/devops-guide/index.html#devops-implementation-env-https-access-secret).
 
 # Notes
 

--- a/helm/amster/templates/config-map.yaml
+++ b/helm/amster/templates/config-map.yaml
@@ -20,7 +20,7 @@ data:
     --pwdEncKey {{ .Values.encryptionKey }} \
     --acceptLicense \
     --lbSiteName site1 \
-    --lbPrimaryUrl {{ if .Values.useTLS }}https{{else}}http{{end}}://{{ template "fqdn" . }}/openam \
+    --lbPrimaryUrl {{ if or (eq .Values.tlsStrategy "https") (eq .Values.tlsStrategy "https-cert-manager") }}https{{else}}http{{end}}://{{ template "fqdn" . }}/openam \
     --cfgDir /home/forgerock/openam
     :exit
   01_import.amster: |

--- a/helm/apache-agent/values.yaml
+++ b/helm/apache-agent/values.yaml
@@ -10,8 +10,13 @@ image:
   repository: forgerock-docker-public.bintray.io/forgerock/apache-agent
   tag: latest
   pullPolicy: Always
-# If you set this to true, you must have a TLS secret with the same name as the FQDN.
-useTLS: false
+
+# Select TLS strategy for your deployment:
+# 1) http  - no tls set. Using http only (unencrypted).
+# 2) https - tls enabled.  Provide own certificates.
+# 3) https-cert-manager - tls enabled. Uses Cert-Manager to automatically generate certificates.
+# For options 2 and 3, see ../helm/README.md for more information.
+tlsStrategy: http
 
 # To use this chart, you need to make sure you have agent profile configured
 # in selected amServer. User and password must match profile in amServer

--- a/helm/openam/templates/_helpers.tpl
+++ b/helm/openam/templates/_helpers.tpl
@@ -46,7 +46,7 @@ We truncate at 24 chars because some Kubernetes name fields are limited to this
 
 {{/* Inject the TLS spec into the ingress if tls is globally enabled */}}
 {{- define "tls-spec" -}}
-{{ if .Values.useTLS -}}
+{{ if or (eq .Values.tlsStrategy "https") (eq .Values.tlsStrategy "https-cert-manager") -}}
 tls:
 - hosts:
   - {{ template "externalFQDN" .  }}

--- a/helm/openam/templates/tls.yaml
+++ b/helm/openam/templates/tls.yaml
@@ -1,6 +1,6 @@
 # cert-manager certificate object created if 'tls.strategy: CertManager'. 
 # This object triggers a certificate request to Let's Encrypt via the cert-manager operator.
-{{ if and .Values.useCertManager .Values.useTLS }}
+{{ if eq .Values.tlsStrategy "https-cert-manager" }}
 apiVersion: certmanager.k8s.io/v1alpha1
 kind: Certificate
 metadata:

--- a/helm/openam/values.yaml
+++ b/helm/openam/values.yaml
@@ -42,11 +42,13 @@ catalinaOpts: >
 #-Dcom.sun.management.jmxremote.rmi.port=<port>
 #-Djava.rmi.server.hostname=$HOST_HOSTNAME
 
-# To enable any of the products to use HTTPS on their external endpoint, set the following flag to true.
-useTLS: false
-# The default behaviour when useTLS = true, is to have cert-manager to manage the certificate request/renewal via Let's Encrypt.
-# This is enabled by the following flag:
-useCertManager: true
+# Select TLS strategy for your deployment:
+# 1) http  - no tls set. Using http only (unencrypted).
+# 2) https - tls enabled.  Provide own certificates.
+# 3) https-cert-manager - tls enabled. Uses Cert-Manager to automatically generate certificates.
+# For options 2 and 3, see ../helm/README.md for more information.
+tlsStrategy: http
+
 
 # To use a tomcat web.xml from a k8s config map instead of the one built into the container, set the following to true.
 useConfigMapWebxml: false

--- a/helm/openidm/templates/_helpers.tpl
+++ b/helm/openidm/templates/_helpers.tpl
@@ -23,7 +23,7 @@ Expand the name of the chart.
 
 {{/* Inject the TLS spec into the ingress if tls is globally enabled */}}
 {{- define "tls-spec" -}}
-{{ if .Values.useTLS -}}
+{{ if or (eq .Values.tlsStrategy "https") (eq .Values.tlsStrategy "https-cert-manager") -}}
 tls:
 - hosts:
   - {{ template "externalFQDN" .  }}

--- a/helm/openidm/templates/tls.yaml
+++ b/helm/openidm/templates/tls.yaml
@@ -1,6 +1,6 @@
 # cert-manager certificate object created if 'tls.strategy: CertManager'. 
 # This object triggers a certificate request to Let's Encrypt via the cert-manager operator.
-{{ if and .Values.useCertManager .Values.useTLS }}
+{{ if eq .Values.tlsStrategy "https-cert-manager" }}
 apiVersion: certmanager.k8s.io/v1alpha1
 kind: Certificate
 metadata:

--- a/helm/openidm/values.yaml
+++ b/helm/openidm/values.yaml
@@ -34,11 +34,12 @@ image:
 # override Java JVM options.
 javaOpts: "-Xmx1024m -server -XX:+UseG1GC"
 
-# To enable any of the products to use HTTPS on their external endpoint, set the following flag to true.
-useTLS: false
-# The default behaviour when useTLS = true, is to have cert-manager to manage the certificate request/renewal via Let's Encrypt.
-# This is enabled by the following flag:
-useCertManager: true
+# Select TLS strategy for your deployment:
+# 1) http  - no tls set. Using http only (unencrypted).
+# 2) https - tls enabled.  Provide own certificates.
+# 3) https-cert-manager - tls enabled. Uses Cert-Manager to automatically generate certificates.
+# For options 2 and 3, see ../helm/README.md for more information.
+tlsStrategy: http
 
 # Specific values
 openidm:

--- a/helm/openig/templates/_helpers.tpl
+++ b/helm/openig/templates/_helpers.tpl
@@ -26,7 +26,7 @@ We truncate at 24 chars because some Kubernetes name fields are limited to this 
 
 {{/* Inject the TLS spec into the ingress if tls is globally enabled */}}
 {{- define "tls-spec" -}}
-{{ if .Values.useTLS -}}
+{{ if or (eq .Values.tlsStrategy "https") (eq .Values.tlsStrategy "https-cert-manager") -}}
 tls:
 - hosts:
   - {{ template "externalFQDN" .  }}

--- a/helm/openig/templates/tls.yaml
+++ b/helm/openig/templates/tls.yaml
@@ -1,6 +1,6 @@
 # cert-manager certificate object created if 'tls.strategy: CertManager'. 
 # This object triggers a certificate request to Let's Encrypt via the cert-manager operator.
-{{ if and .Values.useCertManager .Values.useTLS }}
+{{ if eq .Values.tlsStrategy "https-cert-manager" }}
 apiVersion: certmanager.k8s.io/v1alpha1
 kind: Certificate
 metadata:

--- a/helm/openig/values.yaml
+++ b/helm/openig/values.yaml
@@ -23,12 +23,13 @@ config:
 
 # Tomcat JVM options.
 catalinaOpts: "-Xmx512m"
-  
-# To enable any of the products to use HTTPS on their external endpoint, set the following flag to true.
-useTLS: false
-# The default behaviour when useTLS = true, is to have cert-manager to manage the certificate request/renewal via Let's Encrypt.  
-# This is enabled by the following flag:
-useCertManager: true
+
+# Select TLS strategy for your deployment:
+# 1) http  - no tls set. Using http only (unencrypted).
+# 2) https - tls enabled.  Provide own certificates.
+# 3) https-cert-manager - tls enabled. Uses Cert-Manager to automatically generate certificates.
+# For options 2 and 3, see ../helm/README.md for more information.
+tlsStrategy: https
 
 image:
   repository: forgerock-docker-public.bintray.io/forgerock/openig

--- a/samples/config/dev-benchmark-ig/openig.yaml
+++ b/samples/config/dev-benchmark-ig/openig.yaml
@@ -16,8 +16,7 @@ config:
 ingress:
   hostname: openig.ig-benchmark.forgeops.com
 
-useTLS: false
-useCertManager: false
+tlsStrategy: http
 
 resources:
   limits:

--- a/samples/config/dev/common.yaml
+++ b/samples/config/dev/common.yaml
@@ -6,6 +6,5 @@ image:
   tag: 6.5.0
   pullPolicy: IfNotPresent
 
-useTLS: false
-useCertManager: false
+tlsStrategy: http
   


### PR DESCRIPTION
As previous discussed with David, I've remove the useTLS and useCertManager options and replaced them with a single option tlsStrategy.  This has been added to AM,IG and IDM and tested.

helm/readme updated too.