### PR TITLE
Updates to get smoke tests back to green

### DIFF
--- a/cicd/toolbox/docker-entrypoint.sh
+++ b/cicd/toolbox/docker-entrypoint.sh
@@ -4,7 +4,9 @@
 echo "Cmd is $1"
 
 echo "Cloning forgeops"
-cd /
+mkdir -p /workspace
+
+cd /workspace
 git clone https://github.com/ForgeRock/forgeops.git 
 
 # configure context so kubens does not complain

--- a/cicd/toolbox/run-smoke-tests.sh
+++ b/cicd/toolbox/run-smoke-tests.sh
@@ -1,18 +1,20 @@
 #!/usr/bin/env bash
-
-
+# Work in progress !
+# Assumes forgeops source is checked out to /workspace/forgeops
+cd /workspace/forgeops
 
 # Namespace is provided in $1
 clean_ns() {
     echo "Cleaning up older deployments"
     kubens $1
-    /forgeops/bin/remove-all.sh 
+    ./bin/remove-all.sh 
+    kubectl delete secret frconfig
+    kubectl delete configmap frconfig
 }
 
 deploy_smoke() {
     echo "deploying the smoke test configuration"
-    cd /forgeops
-    bin/deploy.sh samples/config/smoke-deployment
+    ./bin/deploy.sh samples/config/smoke-deployment
 }
 
 

--- a/docker/csv/dev.csv
+++ b/docker/csv/dev.csv
@@ -2,7 +2,7 @@ java,6.5.0
 ds,6.5.0-M129.1,6.5.0-M129.1.2
 openam,6.5.0-M7,latest
 amster,6.5.0-M7,latest
-openidm,6.5.0-M4,latest
+openidm,6.5.0-M5,latest
 openig,6.5.0-M134,latest
 git,6.5.0
 nginx-agent,6.5.0

--- a/helm/frconfig/templates/config-map.yaml
+++ b/helm/frconfig/templates/config-map.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Values.config.name }}
-  annotations:
-    "helm.sh/resource-policy": keep
+  # annotations:
+  #   "helm.sh/resource-policy": keep
 data:
   GIT_REPO: "{{ .Values.git.repo }}"
   GIT_AUTOSAVE_BRANCH:  autosave-{{ .Release.Namespace }}

--- a/helm/frconfig/templates/secret.yaml
+++ b/helm/frconfig/templates/secret.yaml
@@ -3,8 +3,8 @@ apiVersion: v1
 kind: Secret
 metadata:
     name: {{ .Values.config.name }}
-    annotations:
-      "helm.sh/resource-policy": keep
+    # annotations:
+    #   "helm.sh/resource-policy": keep
 type: Opaque
 data:
   id_rsa:

--- a/helm/frconfig/values.yaml
+++ b/helm/frconfig/values.yaml
@@ -1,6 +1,8 @@
 # Default values for frconfig.
 # This is a YAML-formatted file.
 
+# Top level domain, including the leading dot. This is used to form the wild-card cert request for cert-manager.
+domain: .example.com
 
 config:
   # The default name that products use when looking for the configmap and secret is `frconfig`.

--- a/helm/openidm/values.yaml
+++ b/helm/openidm/values.yaml
@@ -26,7 +26,7 @@ component: openidm
 
 image:
   repository: forgerock-docker-public.bintray.io/forgerock/openidm
-  tag: 6.5.0-M4
+  tag: 6.5.0-M5
   pullPolicy: IfNotPresent
   # For development use Always
   # pullPolicy: Always

--- a/samples/config/smoke-deployment/amster.yaml
+++ b/samples/config/smoke-deployment/amster.yaml
@@ -1,6 +1,4 @@
-image:
-  pullPolicy: Always
-  tag: latest
+
 
 config:
   claim: frconfig

--- a/samples/config/smoke-deployment/apache-agent.yaml
+++ b/samples/config/smoke-deployment/apache-agent.yaml
@@ -3,5 +3,7 @@ agent:
   amServer: http://openam.smoke.forgeops.com/openam
   realm: "/"
 
+
 image:
   pullPolicy: Always
+  tag: 6.5.0 

--- a/samples/config/smoke-deployment/common.yaml
+++ b/samples/config/smoke-deployment/common.yaml
@@ -1,7 +1,7 @@
 domain: .forgeops.com
 
-image:
-  tag: 6.5.0
-  pullPolicy: Always
 
-tlsStrategy: http
+certmanager:
+  acme: true
+  issuer: letsencrypt-prod
+  issuerKind: ClusterIssuer

--- a/samples/config/smoke-deployment/configstore.yaml
+++ b/samples/config/smoke-deployment/configstore.yaml
@@ -1,5 +1,1 @@
 instance: configstore
-
-image:
-  pullPolicy: Always
-  tag: latest

--- a/samples/config/smoke-deployment/ctsstore.yaml
+++ b/samples/config/smoke-deployment/ctsstore.yaml
@@ -1,6 +1,1 @@
-bootstrapType: cts
 instance: ctsstore
-
-image:
-  pullPolicy: Always
-  tag: latest

--- a/samples/config/smoke-deployment/nginx-agent.yaml
+++ b/samples/config/smoke-deployment/nginx-agent.yaml
@@ -2,3 +2,8 @@ agent:
   user: nginx
   amServer: http://openam.smoke.forgeops.com/openam
   realm: "/"
+
+
+image:
+  pullPolicy: Always
+  tag: 6.5.0 

--- a/samples/config/smoke-deployment/openam.yaml
+++ b/samples/config/smoke-deployment/openam.yaml
@@ -1,3 +1,3 @@
-image:
-  pullPolicy: Always
-  tag: latest
+# image:
+#   pullPolicy: Always
+#   tag: latest

--- a/samples/config/smoke-deployment/openidm.yaml
+++ b/samples/config/smoke-deployment/openidm.yaml
@@ -1,6 +1,6 @@
 config:
   path: /git/config/6.5/smoke-tests/idm/
 
-image:
-  pullPolicy: Always
-  tag: latest
+# image:
+#   pullPolicy: Always
+#   tag: latest

--- a/samples/config/smoke-deployment/openig.yaml
+++ b/samples/config/smoke-deployment/openig.yaml
@@ -1,3 +1,3 @@
-image:
-  pullPolicy: Always
-  tag: latest
+# image:
+#   pullPolicy: Always
+#   tag: latest

--- a/samples/config/smoke-deployment/userstore.yaml
+++ b/samples/config/smoke-deployment/userstore.yaml
@@ -1,5 +1,5 @@
 instance: userstore
 
-image:
-  pullPolicy: Always
-  tag: latest
+# image:
+#   pullPolicy: Always
+#   tag: latest


### PR DESCRIPTION
- Default to SSL everywhere, and use our lets encrypt issuer
- update smoke sample config files
- default frconfig to *deleting* the git secret when the chart is deleted