### PR TITLE
add hardcoded password validators since config is not meant to be changed post-deployment

### DIFF
--- a/docker/ds/bootstrap/config-changes.ldif
+++ b/docker/ds/bootstrap/config-changes.ldif
@@ -90,3 +90,592 @@ changetype: modify
 replace: ds-cfg-replication-db-directory
 ds-cfg-replication-db-directory: &{changelog.db.directory|changelogDb}
 
+
+# Pre-populate password validators for common scenarios
+dn: cn=Upper Case Characters,cn=Password Validators,cn=config
+objectClass: top
+objectClass: ds-cfg-password-validator
+objectClass: ds-cfg-character-set-password-validator
+cn: Upper Case Characters
+ds-cfg-java-class: org.opends.server.extensions.CharacterSetPasswordValidator
+ds-cfg-enabled: true
+ds-cfg-character-set: 1:ABCDEFGHIJKLMNOPQRSTUVWXYZ
+ds-cfg-allow-unclassified-characters: true
+
+dn: cn=Lower Case Characters,cn=Password Validators,cn=config
+objectClass: top
+objectClass: ds-cfg-password-validator
+objectClass: ds-cfg-character-set-password-validator
+cn: Lower Case Characters
+ds-cfg-java-class: org.opends.server.extensions.CharacterSetPasswordValidator
+ds-cfg-enabled: true
+ds-cfg-character-set: 1:abcdefghijklmnopqrstuvwxyz
+ds-cfg-allow-unclassified-characters: true
+
+dn: cn=Numeric Characters,cn=Password Validators,cn=config
+objectClass: top
+objectClass: ds-cfg-password-validator
+objectClass: ds-cfg-character-set-password-validator
+cn: Numeric Characters
+ds-cfg-java-class: org.opends.server.extensions.CharacterSetPasswordValidator
+ds-cfg-enabled: true
+ds-cfg-character-set: 1:0123456789
+ds-cfg-allow-unclassified-characters: true
+
+dn: cn=Special Characters,cn=Password Validators,cn=config
+objectClass: top
+objectClass: ds-cfg-password-validator
+objectClass: ds-cfg-character-set-password-validator
+cn: Special Characters
+ds-cfg-java-class: org.opends.server.extensions.CharacterSetPasswordValidator
+ds-cfg-enabled: true
+ds-cfg-character-set: 1:~!@#$%^&*()-_=+[]{}|;:,.<>/?
+ds-cfg-allow-unclassified-characters: true
+
+dn: cn=givenName attribute value,cn=Password Validators,cn=config
+objectClass: top
+objectClass: ds-cfg-password-validator
+objectClass: ds-cfg-attribute-value-password-validator
+cn: givenName attribute value
+match-attribute: givenName
+ds-cfg-java-class: org.opends.server.extensions.AttributeValuePasswordValidator
+ds-cfg-enabled: true
+ds-cfg-test-reversed-password: true
+ds-cfg-check-substrings: true
+
+dn: cn=sn attribute value,cn=Password Validators,cn=config
+objectClass: top
+objectClass: ds-cfg-password-validator
+objectClass: ds-cfg-attribute-value-password-validator
+cn: sn attribute value
+match-attribute: sn
+ds-cfg-java-class: org.opends.server.extensions.AttributeValuePasswordValidator
+ds-cfg-enabled: true
+ds-cfg-test-reversed-password: true
+ds-cfg-check-substrings: true
+
+dn: cn=sn and givenName attribute value,cn=Password Validators,cn=config
+objectClass: top
+objectClass: ds-cfg-password-validator
+objectClass: ds-cfg-attribute-value-password-validator
+cn: sn attribute value
+match-attribute: sn
+match-attribute: givenName
+ds-cfg-java-class: org.opends.server.extensions.AttributeValuePasswordValidator
+ds-cfg-enabled: true
+ds-cfg-test-reversed-password: true
+ds-cfg-check-substrings: true
+
+dn: cn=min length 8 validator,cn=Password Validators,cn=config
+objectClass: top
+objectClass: ds-cfg-password-validator
+objectClass: ds-cfg-length-based-password-validator
+cn: min length 8 validator
+ds-cfg-java-class: org.opends.server.extensions.LengthBasedPasswordValidator
+ds-cfg-enabled: true
+ds-cfg-min-password-length: 8
+
+dn: cn=min length 9 validator,cn=Password Validators,cn=config
+objectClass: top
+objectClass: ds-cfg-password-validator
+objectClass: ds-cfg-length-based-password-validator
+cn: min length 9 validator
+ds-cfg-java-class: org.opends.server.extensions.LengthBasedPasswordValidator
+ds-cfg-enabled: true
+ds-cfg-min-password-length: 9
+
+dn: cn=min length 10 validator,cn=Password Validators,cn=config
+objectClass: top
+objectClass: ds-cfg-password-validator
+objectClass: ds-cfg-length-based-password-validator
+cn: min length 10 validator
+ds-cfg-java-class: org.opends.server.extensions.LengthBasedPasswordValidator
+ds-cfg-enabled: true
+ds-cfg-min-password-length: 10
+
+dn: cn=min length 11 validator,cn=Password Validators,cn=config
+objectClass: top
+objectClass: ds-cfg-password-validator
+objectClass: ds-cfg-length-based-password-validator
+cn: min length 11 validator
+ds-cfg-java-class: org.opends.server.extensions.LengthBasedPasswordValidator
+ds-cfg-enabled: true
+ds-cfg-min-password-length: 11
+
+dn: cn=min length 12 validator,cn=Password Validators,cn=config
+objectClass: top
+objectClass: ds-cfg-password-validator
+objectClass: ds-cfg-length-based-password-validator
+cn: min length 12 validator
+ds-cfg-java-class: org.opends.server.extensions.LengthBasedPasswordValidator
+ds-cfg-enabled: true
+ds-cfg-min-password-length: 12
+
+dn: cn=min length 13 validator,cn=Password Validators,cn=config
+objectClass: top
+objectClass: ds-cfg-password-validator
+objectClass: ds-cfg-length-based-password-validator
+cn: min length 13 validator
+ds-cfg-java-class: org.opends.server.extensions.LengthBasedPasswordValidator
+ds-cfg-enabled: true
+ds-cfg-min-password-length: 13
+
+dn: cn=min length 14 validator,cn=Password Validators,cn=config
+objectClass: top
+objectClass: ds-cfg-password-validator
+objectClass: ds-cfg-length-based-password-validator
+cn: min length 14 validator
+ds-cfg-java-class: org.opends.server.extensions.LengthBasedPasswordValidator
+ds-cfg-enabled: true
+ds-cfg-min-password-length: 14
+
+dn: cn=min length 15 validator,cn=Password Validators,cn=config
+objectClass: top
+objectClass: ds-cfg-password-validator
+objectClass: ds-cfg-length-based-password-validator
+cn: min length 15 validator
+ds-cfg-java-class: org.opends.server.extensions.LengthBasedPasswordValidator
+ds-cfg-enabled: true
+ds-cfg-min-password-length: 15
+
+dn: cn=min length 16 validator,cn=Password Validators,cn=config
+objectClass: top
+objectClass: ds-cfg-password-validator
+objectClass: ds-cfg-length-based-password-validator
+cn: min length 16 validator
+ds-cfg-java-class: org.opends.server.extensions.LengthBasedPasswordValidator
+ds-cfg-enabled: true
+ds-cfg-min-password-length: 16
+
+dn: cn=min length 17 validator,cn=Password Validators,cn=config
+objectClass: top
+objectClass: ds-cfg-password-validator
+objectClass: ds-cfg-length-based-password-validator
+cn: min length 17 validator
+ds-cfg-java-class: org.opends.server.extensions.LengthBasedPasswordValidator
+ds-cfg-enabled: true
+ds-cfg-min-password-length: 17
+
+dn: cn=min length 18 validator,cn=Password Validators,cn=config
+objectClass: top
+objectClass: ds-cfg-password-validator
+objectClass: ds-cfg-length-based-password-validator
+cn: min length 18 validator
+ds-cfg-java-class: org.opends.server.extensions.LengthBasedPasswordValidator
+ds-cfg-enabled: true
+ds-cfg-min-password-length: 18
+
+dn: cn=min length 19 validator,cn=Password Validators,cn=config
+objectClass: top
+objectClass: ds-cfg-password-validator
+objectClass: ds-cfg-length-based-password-validator
+cn: min length 19 validator
+ds-cfg-java-class: org.opends.server.extensions.LengthBasedPasswordValidator
+ds-cfg-enabled: true
+ds-cfg-min-password-length: 19
+
+dn: cn=min length 20 validator,cn=Password Validators,cn=config
+objectClass: top
+objectClass: ds-cfg-password-validator
+objectClass: ds-cfg-length-based-password-validator
+cn: min length 20 validator
+ds-cfg-java-class: org.opends.server.extensions.LengthBasedPasswordValidator
+ds-cfg-enabled: true
+ds-cfg-min-password-length: 20
+
+dn: cn=min length 21 validator,cn=Password Validators,cn=config
+objectClass: top
+objectClass: ds-cfg-password-validator
+objectClass: ds-cfg-length-based-password-validator
+cn: min length 21 validator
+ds-cfg-java-class: org.opends.server.extensions.LengthBasedPasswordValidator
+ds-cfg-enabled: true
+ds-cfg-min-password-length: 21
+
+dn: cn=min length 22 validator,cn=Password Validators,cn=config
+objectClass: top
+objectClass: ds-cfg-password-validator
+objectClass: ds-cfg-length-based-password-validator
+cn: min length 22 validator
+ds-cfg-java-class: org.opends.server.extensions.LengthBasedPasswordValidator
+ds-cfg-enabled: true
+ds-cfg-min-password-length: 22
+
+dn: cn=min length 23 validator,cn=Password Validators,cn=config
+objectClass: top
+objectClass: ds-cfg-password-validator
+objectClass: ds-cfg-length-based-password-validator
+cn: min length 23 validator
+ds-cfg-java-class: org.opends.server.extensions.LengthBasedPasswordValidator
+ds-cfg-enabled: true
+ds-cfg-min-password-length: 23
+
+dn: cn=min length 24 validator,cn=Password Validators,cn=config
+objectClass: top
+objectClass: ds-cfg-password-validator
+objectClass: ds-cfg-length-based-password-validator
+cn: min length 24 validator
+ds-cfg-java-class: org.opends.server.extensions.LengthBasedPasswordValidator
+ds-cfg-enabled: true
+ds-cfg-min-password-length: 24
+
+dn: cn=min length 25 validator,cn=Password Validators,cn=config
+objectClass: top
+objectClass: ds-cfg-password-validator
+objectClass: ds-cfg-length-based-password-validator
+cn: min length 25 validator
+ds-cfg-java-class: org.opends.server.extensions.LengthBasedPasswordValidator
+ds-cfg-enabled: true
+ds-cfg-min-password-length: 25
+
+dn: cn=min length 26 validator,cn=Password Validators,cn=config
+objectClass: top
+objectClass: ds-cfg-password-validator
+objectClass: ds-cfg-length-based-password-validator
+cn: min length 26 validator
+ds-cfg-java-class: org.opends.server.extensions.LengthBasedPasswordValidator
+ds-cfg-enabled: true
+ds-cfg-min-password-length: 26
+
+dn: cn=min length 27 validator,cn=Password Validators,cn=config
+objectClass: top
+objectClass: ds-cfg-password-validator
+objectClass: ds-cfg-length-based-password-validator
+cn: min length 27 validator
+ds-cfg-java-class: org.opends.server.extensions.LengthBasedPasswordValidator
+ds-cfg-enabled: true
+ds-cfg-min-password-length: 27
+
+dn: cn=min length 28 validator,cn=Password Validators,cn=config
+objectClass: top
+objectClass: ds-cfg-password-validator
+objectClass: ds-cfg-length-based-password-validator
+cn: min length 28 validator
+ds-cfg-java-class: org.opends.server.extensions.LengthBasedPasswordValidator
+ds-cfg-enabled: true
+ds-cfg-min-password-length: 28
+
+dn: cn=min length 29 validator,cn=Password Validators,cn=config
+objectClass: top
+objectClass: ds-cfg-password-validator
+objectClass: ds-cfg-length-based-password-validator
+cn: min length 29 validator
+ds-cfg-java-class: org.opends.server.extensions.LengthBasedPasswordValidator
+ds-cfg-enabled: true
+ds-cfg-min-password-length: 29
+
+dn: cn=min length 30 validator,cn=Password Validators,cn=config
+objectClass: top
+objectClass: ds-cfg-password-validator
+objectClass: ds-cfg-length-based-password-validator
+cn: min length 30 validator
+ds-cfg-java-class: org.opends.server.extensions.LengthBasedPasswordValidator
+ds-cfg-enabled: true
+ds-cfg-min-password-length: 30
+
+dn: cn=min length 31 validator,cn=Password Validators,cn=config
+objectClass: top
+objectClass: ds-cfg-password-validator
+objectClass: ds-cfg-length-based-password-validator
+cn: min length 31 validator
+ds-cfg-java-class: org.opends.server.extensions.LengthBasedPasswordValidator
+ds-cfg-enabled: true
+ds-cfg-min-password-length: 31
+
+dn: cn=min length 32 validator,cn=Password Validators,cn=config
+objectClass: top
+objectClass: ds-cfg-password-validator
+objectClass: ds-cfg-length-based-password-validator
+cn: min length 32 validator
+ds-cfg-java-class: org.opends.server.extensions.LengthBasedPasswordValidator
+ds-cfg-enabled: true
+ds-cfg-min-password-length: 32
+
+dn: cn=min length 33 validator,cn=Password Validators,cn=config
+objectClass: top
+objectClass: ds-cfg-password-validator
+objectClass: ds-cfg-length-based-password-validator
+cn: min length 33 validator
+ds-cfg-java-class: org.opends.server.extensions.LengthBasedPasswordValidator
+ds-cfg-enabled: true
+ds-cfg-min-password-length: 33
+
+dn: cn=min length 34 validator,cn=Password Validators,cn=config
+objectClass: top
+objectClass: ds-cfg-password-validator
+objectClass: ds-cfg-length-based-password-validator
+cn: min length 34 validator
+ds-cfg-java-class: org.opends.server.extensions.LengthBasedPasswordValidator
+ds-cfg-enabled: true
+ds-cfg-min-password-length: 34
+
+dn: cn=min length 35 validator,cn=Password Validators,cn=config
+objectClass: top
+objectClass: ds-cfg-password-validator
+objectClass: ds-cfg-length-based-password-validator
+cn: min length 35 validator
+ds-cfg-java-class: org.opends.server.extensions.LengthBasedPasswordValidator
+ds-cfg-enabled: true
+ds-cfg-min-password-length: 35
+
+dn: cn=min length 36 validator,cn=Password Validators,cn=config
+objectClass: top
+objectClass: ds-cfg-password-validator
+objectClass: ds-cfg-length-based-password-validator
+cn: min length 36 validator
+ds-cfg-java-class: org.opends.server.extensions.LengthBasedPasswordValidator
+ds-cfg-enabled: true
+ds-cfg-min-password-length: 36
+
+dn: cn=min length 37 validator,cn=Password Validators,cn=config
+objectClass: top
+objectClass: ds-cfg-password-validator
+objectClass: ds-cfg-length-based-password-validator
+cn: min length 37 validator
+ds-cfg-java-class: org.opends.server.extensions.LengthBasedPasswordValidator
+ds-cfg-enabled: true
+ds-cfg-min-password-length: 37
+
+dn: cn=min length 38 validator,cn=Password Validators,cn=config
+objectClass: top
+objectClass: ds-cfg-password-validator
+objectClass: ds-cfg-length-based-password-validator
+cn: min length 38 validator
+ds-cfg-java-class: org.opends.server.extensions.LengthBasedPasswordValidator
+ds-cfg-enabled: true
+ds-cfg-min-password-length: 38
+
+dn: cn=min length 39 validator,cn=Password Validators,cn=config
+objectClass: top
+objectClass: ds-cfg-password-validator
+objectClass: ds-cfg-length-based-password-validator
+cn: min length 39 validator
+ds-cfg-java-class: org.opends.server.extensions.LengthBasedPasswordValidator
+ds-cfg-enabled: true
+ds-cfg-min-password-length: 39
+
+dn: cn=min length 40 validator,cn=Password Validators,cn=config
+objectClass: top
+objectClass: ds-cfg-password-validator
+objectClass: ds-cfg-length-based-password-validator
+cn: min length 40 validator
+ds-cfg-java-class: org.opends.server.extensions.LengthBasedPasswordValidator
+ds-cfg-enabled: true
+ds-cfg-min-password-length: 40
+
+dn: cn=min length 41 validator,cn=Password Validators,cn=config
+objectClass: top
+objectClass: ds-cfg-password-validator
+objectClass: ds-cfg-length-based-password-validator
+cn: min length 41 validator
+ds-cfg-java-class: org.opends.server.extensions.LengthBasedPasswordValidator
+ds-cfg-enabled: true
+ds-cfg-min-password-length: 41
+
+dn: cn=min length 42 validator,cn=Password Validators,cn=config
+objectClass: top
+objectClass: ds-cfg-password-validator
+objectClass: ds-cfg-length-based-password-validator
+cn: min length 42 validator
+ds-cfg-java-class: org.opends.server.extensions.LengthBasedPasswordValidator
+ds-cfg-enabled: true
+ds-cfg-min-password-length: 42
+
+dn: cn=min length 43 validator,cn=Password Validators,cn=config
+objectClass: top
+objectClass: ds-cfg-password-validator
+objectClass: ds-cfg-length-based-password-validator
+cn: min length 43 validator
+ds-cfg-java-class: org.opends.server.extensions.LengthBasedPasswordValidator
+ds-cfg-enabled: true
+ds-cfg-min-password-length: 43
+
+dn: cn=min length 44 validator,cn=Password Validators,cn=config
+objectClass: top
+objectClass: ds-cfg-password-validator
+objectClass: ds-cfg-length-based-password-validator
+cn: min length 44 validator
+ds-cfg-java-class: org.opends.server.extensions.LengthBasedPasswordValidator
+ds-cfg-enabled: true
+ds-cfg-min-password-length: 44
+
+dn: cn=min length 45 validator,cn=Password Validators,cn=config
+objectClass: top
+objectClass: ds-cfg-password-validator
+objectClass: ds-cfg-length-based-password-validator
+cn: min length 45 validator
+ds-cfg-java-class: org.opends.server.extensions.LengthBasedPasswordValidator
+ds-cfg-enabled: true
+ds-cfg-min-password-length: 45
+
+dn: cn=min length 46 validator,cn=Password Validators,cn=config
+objectClass: top
+objectClass: ds-cfg-password-validator
+objectClass: ds-cfg-length-based-password-validator
+cn: min length 46 validator
+ds-cfg-java-class: org.opends.server.extensions.LengthBasedPasswordValidator
+ds-cfg-enabled: true
+ds-cfg-min-password-length: 46
+
+dn: cn=min length 47 validator,cn=Password Validators,cn=config
+objectClass: top
+objectClass: ds-cfg-password-validator
+objectClass: ds-cfg-length-based-password-validator
+cn: min length 47 validator
+ds-cfg-java-class: org.opends.server.extensions.LengthBasedPasswordValidator
+ds-cfg-enabled: true
+ds-cfg-min-password-length: 47
+
+dn: cn=min length 48 validator,cn=Password Validators,cn=config
+objectClass: top
+objectClass: ds-cfg-password-validator
+objectClass: ds-cfg-length-based-password-validator
+cn: min length 48 validator
+ds-cfg-java-class: org.opends.server.extensions.LengthBasedPasswordValidator
+ds-cfg-enabled: true
+ds-cfg-min-password-length: 48
+
+dn: cn=min length 49 validator,cn=Password Validators,cn=config
+objectClass: top
+objectClass: ds-cfg-password-validator
+objectClass: ds-cfg-length-based-password-validator
+cn: min length 49 validator
+ds-cfg-java-class: org.opends.server.extensions.LengthBasedPasswordValidator
+ds-cfg-enabled: true
+ds-cfg-min-password-length: 49
+
+dn: cn=min length 50 validator,cn=Password Validators,cn=config
+objectClass: top
+objectClass: ds-cfg-password-validator
+objectClass: ds-cfg-length-based-password-validator
+cn: min length 50 validator
+ds-cfg-java-class: org.opends.server.extensions.LengthBasedPasswordValidator
+ds-cfg-enabled: true
+ds-cfg-min-password-length: 50
+
+dn: cn=min length 51 validator,cn=Password Validators,cn=config
+objectClass: top
+objectClass: ds-cfg-password-validator
+objectClass: ds-cfg-length-based-password-validator
+cn: min length 51 validator
+ds-cfg-java-class: org.opends.server.extensions.LengthBasedPasswordValidator
+ds-cfg-enabled: true
+ds-cfg-min-password-length: 51
+
+dn: cn=min length 52 validator,cn=Password Validators,cn=config
+objectClass: top
+objectClass: ds-cfg-password-validator
+objectClass: ds-cfg-length-based-password-validator
+cn: min length 52 validator
+ds-cfg-java-class: org.opends.server.extensions.LengthBasedPasswordValidator
+ds-cfg-enabled: true
+ds-cfg-min-password-length: 52
+
+dn: cn=min length 53 validator,cn=Password Validators,cn=config
+objectClass: top
+objectClass: ds-cfg-password-validator
+objectClass: ds-cfg-length-based-password-validator
+cn: min length 53 validator
+ds-cfg-java-class: org.opends.server.extensions.LengthBasedPasswordValidator
+ds-cfg-enabled: true
+ds-cfg-min-password-length: 53
+
+dn: cn=min length 54 validator,cn=Password Validators,cn=config
+objectClass: top
+objectClass: ds-cfg-password-validator
+objectClass: ds-cfg-length-based-password-validator
+cn: min length 54 validator
+ds-cfg-java-class: org.opends.server.extensions.LengthBasedPasswordValidator
+ds-cfg-enabled: true
+ds-cfg-min-password-length: 54
+
+dn: cn=min length 55 validator,cn=Password Validators,cn=config
+objectClass: top
+objectClass: ds-cfg-password-validator
+objectClass: ds-cfg-length-based-password-validator
+cn: min length 55 validator
+ds-cfg-java-class: org.opends.server.extensions.LengthBasedPasswordValidator
+ds-cfg-enabled: true
+ds-cfg-min-password-length: 55
+
+dn: cn=min length 56 validator,cn=Password Validators,cn=config
+objectClass: top
+objectClass: ds-cfg-password-validator
+objectClass: ds-cfg-length-based-password-validator
+cn: min length 56 validator
+ds-cfg-java-class: org.opends.server.extensions.LengthBasedPasswordValidator
+ds-cfg-enabled: true
+ds-cfg-min-password-length: 56
+
+dn: cn=min length 57 validator,cn=Password Validators,cn=config
+objectClass: top
+objectClass: ds-cfg-password-validator
+objectClass: ds-cfg-length-based-password-validator
+cn: min length 57 validator
+ds-cfg-java-class: org.opends.server.extensions.LengthBasedPasswordValidator
+ds-cfg-enabled: true
+ds-cfg-min-password-length: 57
+
+dn: cn=min length 58 validator,cn=Password Validators,cn=config
+objectClass: top
+objectClass: ds-cfg-password-validator
+objectClass: ds-cfg-length-based-password-validator
+cn: min length 58 validator
+ds-cfg-java-class: org.opends.server.extensions.LengthBasedPasswordValidator
+ds-cfg-enabled: true
+ds-cfg-min-password-length: 58
+
+dn: cn=min length 59 validator,cn=Password Validators,cn=config
+objectClass: top
+objectClass: ds-cfg-password-validator
+objectClass: ds-cfg-length-based-password-validator
+cn: min length 59 validator
+ds-cfg-java-class: org.opends.server.extensions.LengthBasedPasswordValidator
+ds-cfg-enabled: true
+ds-cfg-min-password-length: 59
+
+dn: cn=min length 60 validator,cn=Password Validators,cn=config
+objectClass: top
+objectClass: ds-cfg-password-validator
+objectClass: ds-cfg-length-based-password-validator
+cn: min length 60 validator
+ds-cfg-java-class: org.opends.server.extensions.LengthBasedPasswordValidator
+ds-cfg-enabled: true
+ds-cfg-min-password-length: 60
+
+dn: cn=min length 61 validator,cn=Password Validators,cn=config
+objectClass: top
+objectClass: ds-cfg-password-validator
+objectClass: ds-cfg-length-based-password-validator
+cn: min length 61 validator
+ds-cfg-java-class: org.opends.server.extensions.LengthBasedPasswordValidator
+ds-cfg-enabled: true
+ds-cfg-min-password-length: 61
+
+dn: cn=min length 62 validator,cn=Password Validators,cn=config
+objectClass: top
+objectClass: ds-cfg-password-validator
+objectClass: ds-cfg-length-based-password-validator
+cn: min length 62 validator
+ds-cfg-java-class: org.opends.server.extensions.LengthBasedPasswordValidator
+ds-cfg-enabled: true
+ds-cfg-min-password-length: 62
+
+dn: cn=min length 63 validator,cn=Password Validators,cn=config
+objectClass: top
+objectClass: ds-cfg-password-validator
+objectClass: ds-cfg-length-based-password-validator
+cn: min length 63 validator
+ds-cfg-java-class: org.opends.server.extensions.LengthBasedPasswordValidator
+ds-cfg-enabled: true
+ds-cfg-min-password-length: 63
+
+dn: cn=min length 64 validator,cn=Password Validators,cn=config
+objectClass: top
+objectClass: ds-cfg-password-validator
+objectClass: ds-cfg-length-based-password-validator
+cn: min length 64 validator
+ds-cfg-java-class: org.opends.server.extensions.LengthBasedPasswordValidator
+ds-cfg-enabled: true
+ds-cfg-min-password-length: 64
+


### PR DESCRIPTION
Moving password policies to subtree entries solves the problem for not modifying the config store, but unfortunately validators are not supported as subentries. This change bootstraps DS with a range of validators that enables password policies to reference these pre-existing validators, and no changes to config are necessary at run time.