### PR TITLE
Update frconfig to slurp the git ssh secret from a file

### DIFF
--- a/helm/frconfig/README.md
+++ b/helm/frconfig/README.md
@@ -29,7 +29,9 @@ git:
 ## git secret
 
 A dummy ssh secret `id_rsa` is stored in the `frconfig` secret. If you need ssh access to your git repository
-you must replace this secret with a real ssh key. For example:
+you must replace this secret with a real ssh key. There are two ways to do this: You can replace the contents of the file `secrets/id_rsa` with your ssh key, or alternatively you can use kubectl commands to replace the dummy secret with the 
+real value. For example:
+
 
 ```shell
 # Generate your own id_rsa and id_rsa.pub keypair, according to the instructions on github or stash,
@@ -39,6 +41,8 @@ kubectl create secret generic frconfig --from-file=id_rsa
 ```
 
 Note the secret file name (the key in the secret map) *must* be id_rsa.  This is the private key that has permissions to clone and/or update your repository (the public part of this key is uploaded to your github or stash repository).
+
+The id_rsa file must be kept private. Do not check this file into source control.
 
 ## Configuration per product
 

--- a/helm/frconfig/secrets/id_rsa
+++ b/helm/frconfig/secrets/id_rsa
@@ -1,0 +1,3 @@
+This is a dummy secret for git ssh access. If you are using a private git repo
+that requires an ssh key, replace this file with your generated id_rsa key,
+See the README.

--- a/helm/frconfig/templates/secret.yaml
+++ b/helm/frconfig/templates/secret.yaml
@@ -1,4 +1,5 @@
-# This is a dummy secret. If you need an ssh access for cloning replace this with a real id_rsa secret.
+# The ssh secret for cloning or pushing to a private git repo using ssh:
+# See the README
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,5 +8,6 @@ metadata:
     #   "helm.sh/resource-policy": keep
 type: Opaque
 data:
+  # Replace the dummy id_rsa file 
   id_rsa:
-    {{ b64enc "This_is_a_dummy_key_for_git_repo_cloning" }}
+    {{ .Files.Get "secrets/id_rsa" | b64enc }}


### PR DESCRIPTION
Updated the readme with instructions on how to change the secret
Added dummy secrets/id_rsa file

frconfig chart now gets the dummy secret from a file helm/frconfig/secrets/id_rsa.  If you use https git repo, no changes. If you need an ssh secret, either manually replace the created secret, or replace the id_rsa file and deploy
