### PR TITLE
CLOUD-834 - add flag to idm to enable/disable writing repo changes

### DIFF
--- a/helm/openidm/templates/configmap.yaml
+++ b/helm/openidm/templates/configmap.yaml
@@ -140,10 +140,10 @@ data:
       # To disable the persisted configuration store set this property to false.
       # This will store the configurations only in memory.
       # See https://ea.forgerock.com/docs/idm/integrators-guide/index.html#chap-configuration 
-      openidm.config.repo.enabled=false
+      openidm.config.repo.enabled={{ .Values.devMode }}
 
       # To stop writes to configuration files, set this property to false; suitable for read-only installations.
-      felix.fileinstall.enableConfigSave=false
+      felix.fileinstall.enableConfigSave={{ .Values.devMode }}
 
       # This needs to be true to boot from json files.
       openidm.fileinstall.enabled=true

--- a/helm/openidm/values.yaml
+++ b/helm/openidm/values.yaml
@@ -21,6 +21,10 @@ config:
   # Using the git strategy, each helm chart pulls the configuration from git using an init container.
   strategy: git
 
+# If devMode is true, IDM will write changes made in the admin UI back to the file system where they can
+# be saved and committed to git.
+devMode: false
+
 # Used to form the FQDN  - see _helpers.tpl
 component: openidm
 


### PR DESCRIPTION
CLOUD-834 - add flag to idm to enable/disable writing repo changes back to the filesystem. 