### PR TITLE
CLOUD-832 - AM Should use secrets from /var/run/secrets directly

### DIFF
--- a/docker/util/am_bootstrap.sh
+++ b/docker/util/am_bootstrap.sh
@@ -24,17 +24,6 @@ is_configured() {
     return $status
 }
 
-copy_secrets() {
-    echo "Copying secrets"
-    mkdir -p "${OPENAM_HOME}/openam"
-    cp  -L /var/run/secrets/openam/.keypass "${OPENAM_HOME}/openam"
-    cp  -L /var/run/secrets/openam/.storepass "${OPENAM_HOME}/openam"
-    cp  -L /var/run/secrets/openam/keystore.jceks "${OPENAM_HOME}/openam"
-    cp  -L /var/run/secrets/openam/keystore.jks "${OPENAM_HOME}/openam"
-    cp  -L /var/run/secrets/openam/authorized_keys "$OPENAM_HOME"
-    cp  -L /var/run/secrets/openam/openam_mon_auth "${OPENAM_HOME}/openam"
-}
-
 bootstrap() {
     if is_configured;
     then
@@ -44,5 +33,4 @@ bootstrap() {
     fi
 }
 
-copy_secrets
 bootstrap

--- a/helm/openam/templates/config-map.yaml
+++ b/helm/openam/templates/config-map.yaml
@@ -14,10 +14,10 @@ data:
      "dsameUser" : "cn=dsameuser,ou=DSAME Users,{{ .Values.rootSuffix }}",
      "keystores" : {
        "default" : {
-         "keyStorePasswordFile" : "{{ .Values.openamHome }}/openam/.storepass",
-         "keyPasswordFile" : "{{ .Values.openamHome }}/openam/.keypass",
+         "keyStorePasswordFile" : "/var/run/secrets/openam/.storepass",
+         "keyPasswordFile" : "/var/run/secrets/openam/.keypass",
          "keyStoreType" : "JCEKS",
-         "keyStoreFile" : "{{ .Values.openamHome }}/openam/keystore.jceks"
+         "keyStoreFile" : "/var/run/secrets/openam/keystore.jceks"
        }
      },
      "configStoreList" : [ {


### PR DESCRIPTION

Updates the AM helm chart  and docker util image to use the secrets directly without needing to copy them to openam/openam
