### PR TITLE
Cloud 824 upgrade prometheus

### DIFF
--- a/etc/prometheus-values/kube-prometheus.yaml
+++ b/etc/prometheus-values/kube-prometheus.yaml
@@ -178,7 +178,7 @@ alertmanager:
         resources:
           requests:
             storage: 50Gi
-      selector: {}
+      #selector: {}
 
 prometheus:
   ## Alertmanagers to which alerts will be sent

--- a/etc/prometheus-values/kube-prometheus.yaml
+++ b/etc/prometheus-values/kube-prometheus.yaml
@@ -23,6 +23,10 @@ global:
   rbacEnable: true
   pspEnable: true
 
+  # Reference to one or more secrets to be used when pulling images
+  imagePullSecrets: []
+  #  - name: "image-pull-secret"
+
 # AlertManager
 deployAlertManager: True
 
@@ -67,7 +71,7 @@ alertmanager:
   ##
   image:
     repository: quay.io/prometheus/alertmanager
-    tag: v0.14.0
+    tag: v0.15.1
 
   ingress:
     ## If true, Alertmanager Ingress will be created
@@ -166,15 +170,15 @@ alertmanager:
   ## Alertmanager StorageSpec for persistent data
   ## Ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/user-guides/storage.md
   ##
-  storageSpec: {}
-  #  volumeClaimTemplate:
-  #    spec:
-  #      storageClassName: gluster
-  #      accessModes: ["ReadWriteOnce"]
-  #      resources:
-  #        requests:
-  #          storage: 50Gi
-  #    selector: {}
+  storageSpec:
+    volumeClaimTemplate:
+      spec:
+        storageClassName: fast
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 50Gi
+      selector: {}
 
 prometheus:
   ## Alertmanagers to which alerts will be sent
@@ -275,7 +279,7 @@ prometheus:
   ##
   routePrefix: /
 
-  ## Rules configmap selector
+  ## Rules PrometheusRule CRD selector
   ## Ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/design.md
   ##
   ## 1. If `matchLabels` is used, `rules.additionalLabels` must contain all the labels from
@@ -283,15 +287,14 @@ prometheus:
   ## 2. If `matchExpressions` is used `rules.additionalLabels` must contain at least one label
   ##    from `matchExpressions` in order to be matched by Prometheus
   ## Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
-  #rulesSelector: {}
-   #rulesSelector: {
+  rulesSelector: {}
+   # rulesSelector: {
    #   matchExpressions: [{key: prometheus, operator: In, values: [example-rules, example-rules-2]}]
    # }
    ### OR
-  #rulesSelector:
-  #  matchLabels: 
-  #    role: alert-rules
-  #    prometheus: monitoring-kube-prometheus
+   # rulesSelector: {
+   #   matchLabels: [{role: example-rules}]
+   # }
 
 
   ## Prometheus alerting & recording rules
@@ -459,6 +462,10 @@ prometheus:
             storage: 100Gi
       #selector: {}
 
+  sidecarsSpec: []
+  # - name: sidecar
+  #   image: registry/name:tag
+  
 # default rules are in templates/general.rules.yaml
 # prometheusRules: {}
 

--- a/samples/config/prometheus-values/m-cluster.yaml
+++ b/samples/config/prometheus-values/m-cluster.yaml
@@ -1,3 +1,60 @@
+# set https to false for GKE. True by default for minikube
+exporter-kubelets:
+  https: false
+  
+# Kube-scheduler
+deployKubeScheduler: False
+
+# Controller Manager
+deployKubeControllerManager: False
+
+alertmanager:
+  ## Alertmanager configuration directives
+  ## Ref: https://prometheus.io/docs/alerting/configuration/
+  ##
+  config:
+    global:
+      resolve_timeout: 5m
+      slack_api_url: 'https://hooks.slack.com/services/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'
+    route:
+      group_by: ['alertname', 'job']
+      group_wait: 30s
+      group_interval: 5m
+      repeat_interval: 4h
+      # All alerts to go to Slack by default
+      receiver: 'slack-medium-cluster'
+      routes: 
+      - match:
+          alertname: DeadMansSwitch
+        receiver: 'null'
+      
+    receivers:
+    - name: 'null'
+    - name: 'slack-medium-cluster'
+      slack_configs:
+      - channel: '#alerts-medium-cluster'
+        text: "Job: {{ .GroupLabels.job }}\nSummary: {{ .CommonAnnotations.summary }}\nDescription: {{ .CommonAnnotations.description }}\n"
+
+
+  ## Alertmanager container image
+  ##
+  image:
+    repository: quay.io/prometheus/alertmanager
+    tag: v0.15.1
+
+  ## Alertmanager StorageSpec for persistent data
+  ## Ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/user-guides/storage.md
+  ##
+  storageSpec:
+    volumeClaimTemplate:
+      spec:
+        storageClassName: fast
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 50Gi
+      #selector: {}
+
 prometheus:
   storageSpec:
     volumeClaimTemplate:

--- a/samples/config/prometheus-values/s-cluster.yaml
+++ b/samples/config/prometheus-values/s-cluster.yaml
@@ -1,3 +1,60 @@
+# set https to false for GKE. True by default for minikube
+exporter-kubelets:
+  https: false
+  
+# Kube-scheduler
+deployKubeScheduler: False
+
+# Controller Manager
+deployKubeControllerManager: False
+
+alertmanager:
+  ## Alertmanager configuration directives
+  ## Ref: https://prometheus.io/docs/alerting/configuration/
+  ##
+  config:
+    global:
+      resolve_timeout: 5m
+      slack_api_url: 'https://hooks.slack.com/services/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'
+    route:
+      group_by: ['alertname', 'job']
+      group_wait: 30s
+      group_interval: 5m
+      repeat_interval: 4h
+      # All alerts to go to Slack by default
+      receiver: 'slack-small-cluster'
+      routes: 
+      - match:
+          alertname: DeadMansSwitch
+        receiver: 'null'
+      
+    receivers:
+    - name: 'null'
+    - name: 'slack-small-cluster'
+      slack_configs:
+      - channel: '#alerts-small-cluster'
+        text: "Job: {{ .GroupLabels.job }}\nSummary: {{ .CommonAnnotations.summary }}\nDescription: {{ .CommonAnnotations.description }}\n"
+      
+
+  ## Alertmanager container image
+  ##
+  image:
+    repository: quay.io/prometheus/alertmanager
+    tag: v0.15.1
+
+  ## Alertmanager StorageSpec for persistent data
+  ## Ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/user-guides/storage.md
+  ##
+  storageSpec:
+    volumeClaimTemplate:
+      spec:
+        storageClassName: fast
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 50Gi
+      #selector: {}
+
 prometheus:
   storageSpec:
     volumeClaimTemplate:


### PR DESCRIPTION
Upgraded Alertmanager version. Prometheus and Grafana were up to date.
Updated kube-prometheus.yaml values with latest from coreos repo.
Updated sample m-cluster and s-cluster prometheus values with correct cluster specific overrides for alerting, as these had been removed.
Added Alertmanager PVC for persistence.
Added -A option to connect-prometheus.sh to connect to Alertmanager UI.