### PR TITLE
Ensuring global OPENDJ_JAVA_ARGS is not used so that userpassword is …

### DIFF
--- a/docker/ds/docker-entrypoint.sh
+++ b/docker/ds/docker-entrypoint.sh
@@ -28,8 +28,9 @@ update_ds_password()
         echo "Can't find the directory manager password file. Won't change the password"
         return
     fi
+
     echo "Updating the directory manager password"
-    pw=`bin/encode-password  -s PBKDF2 -f $DIR_MANAGER_PW_FILE | sed -e 's/Encoded Password:  "//' -e 's/"//g' 2>/dev/null`
+    pw=$(OPENDJ_JAVA_ARGS="-Xmx256m" bin/encode-password  -s PBKDF2 -f $DIR_MANAGER_PW_FILE | sed -e 's/Encoded Password:  "//' -e 's/"//g' 2>/dev/null)
     pw="userPassword: $pw"
     head -n -2  data/db/rootUser/rootUser.ldif >/tmp/pw
     echo "$pw" >>/tmp/pw 
@@ -41,7 +42,7 @@ update_ds_password()
     fi
 
     echo "Updating the monitor user password"
-    pw=`bin/encode-password  -s PBKDF2 -f $MONITOR_PW_FILE | sed -e 's/Encoded Password:  "//' -e 's/"//g' 2>/dev/null`
+    pw=$(OPENDJ_JAVA_ARGS="-Xmx256m" bin/encode-password  -s PBKDF2 -f $MONITOR_PW_FILE | sed -e 's/Encoded Password:  "//' -e 's/"//g' 2>/dev/null`
     pw="userPassword: $pw"
     head -n -2  data/db/monitorUser/monitorUser.ldif >/tmp/pw
     echo "$pw" >>/tmp/pw 


### PR DESCRIPTION
…not corrupted with extraneous stdout