### PR TITLE
Expose www-authenticate header to CORS clients

### DIFF
--- a/samples/fr-platform/rs/config/config.json
+++ b/samples/fr-platform/rs/config/config.json
@@ -21,7 +21,7 @@
                                 }
                             }
                         ],
-                        "handler": "ClientHandler"
+                        "handler": "debugHandler"
                     }
                 }
             }
@@ -33,6 +33,14 @@
                 "captureEntity": true,
                 "captureContext": true
             }
+        },
+        {
+            "name": "debugHandler",
+            "type": "ClientHandler",
+            "capture": [
+                "request",
+                "response"
+            ]
         },
         {
             "name": "authzFailureResponse",

--- a/samples/fr-platform/rs/web.xml
+++ b/samples/fr-platform/rs/web.xml
@@ -43,6 +43,10 @@
     <param-value>Content-Type,X-OpenIDM-NoSession,X-OpenIDM-Username,X-OpenIDM-Password,X-Requested-With,Cache-Control,authorization,accept,Origin,Access-Control-Request-Method,Access-Control-Request-Headers,If-Match</param-value>
     </init-param>
     <init-param>
+    <param-name>cors.exposed.headers</param-name>
+    <param-value>WWW-Authenticate</param-value>
+    </init-param>
+    <init-param>
     <param-name>cors.support.credentials</param-name>
     <param-value>false</param-value>
     </init-param>


### PR DESCRIPTION
Quick change necessary for JS clients to detect the cause of 401 failures.