### PR TITLE
Cloud 829 expose monitoring externally

### DIFF
--- a/bin/deploy-prometheus.sh
+++ b/bin/deploy-prometheus.sh
@@ -57,6 +57,11 @@ if read -t 10 -p "Installing Prometheus Operator and Grafana to '${NAMESPACE}' n
 # Add coreos repo to helm
 helm repo add coreos https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
 
+# Add frconfig chart to use cert-manager to provide TLS certificate for external access
+if [ $OVERRIDE_VALUES ]; then
+  helm upgrade -i ${NAMESPACE}-frconfig ../helm/frconfig/ $OVERRIDE_VALUES
+fi
+
 # Install/Upgrade prometheus-operator
 helm upgrade -i ${NAMESPACE}-prometheus-operator coreos/prometheus-operator --set=rbac.install=true --values ${MONPATH}/prometheus-operator.yaml --namespace=$NAMESPACE
 

--- a/etc/prometheus-values/kube-prometheus.yaml
+++ b/etc/prometheus-values/kube-prometheus.yaml
@@ -1,3 +1,6 @@
+# tls domain if ingress enabled
+# domain: .forgeops.com
+
 # exporter-node configuration
 deployExporterNode: True
 

--- a/helm/forgerock-metrics/README.md
+++ b/helm/forgerock-metrics/README.md
@@ -225,10 +225,10 @@ so its in a different location to the formatted dashboards($PROCESSED_DIR).  Ple
 **```NOTE:```** This script only needs to be ran once.
 
 ### Expose Prometheus and Grafana externally.
-To expose monitoring endpoints externally, add the following ingress section under Prometheus, Grafana and Alertmanager values sections in you override configuration as described in an earlier 'How To'. Here's an example for the Prometheus section:
+To expose monitoring endpoints externally, add the following ingress section under Prometheus, Grafana and Alertmanager values sections in you override configuration as described in an earlier 'How To'. Here's an example for the Grafana section:
 
 ```
-prometheus:
+grafana:
   ingress:
     enabled: true
 

--- a/helm/forgerock-metrics/README.md
+++ b/helm/forgerock-metrics/README.md
@@ -132,9 +132,9 @@ View Alertmanager:
 
 <br />
 
-# How Tos
+# How Tos.
 
-### Configure new endpoints to be scraped by Prometheus
+### Configure new endpoints to be scraped by Prometheus.
 
 If you want Prometheus to scrape metrics from a different product, you need to create a new ServiceMonitor in the  
 exporter-forgerock Helm chart.  Please follow these steps:
@@ -195,7 +195,7 @@ FR products).
 Documentation links are embedded in the values files for guidance.  
 Sample configuration files can be found in the samples/prometheus-values/ folder.  
 
-### Configure alerting rules
+### Configure alerting rules.
 To add new alerting rules, add additional rules to ```fr-alerts.yaml```. fr-alerts.yaml is split into groups with a  
 group for each product and a separate group for cluster rules.  
 
@@ -213,7 +213,7 @@ output text.  The output text also incorporates labels so the info can be dynami
 
 See [Alertmanager configuration](https://prometheus.io/docs/alerting/configuration/) and [Alertmanger notifications](https://prometheus.io/docs/alerting/notifications/) for more details.
 
-### Import Custom Grafana Dashboards
+### Import Custom Grafana Dashboards.
 Grafana comes with a set of predefined Grafana dashboards for viewing Kubernetes and cluster metrics.  Further custom  
 dashboards can be added to the deployment but required some specific formatting so they can be recognised by the Grafana  
 watcher and imported into Grafana.  
@@ -224,7 +224,32 @@ so its in a different location to the formatted dashboards($PROCESSED_DIR).  Ple
 
 **```NOTE:```** This script only needs to be ran once.
 
+### Expose Prometheus and Grafana externally.
+To expose monitoring endpoints externally, add the following ingress section under Prometheus, Grafana and Alertmanager values sections in you override configuration as described in an earlier 'How To'. Here's an example for the Prometheus section:
 
+```
+prometheus:
+  ingress:
+    enabled: true
+
+    annotations: 
+      kubernetes.io/ingress.class: nginx
+      kubernetes.io/tls-acme: "true"
+
+    labels:
+      group: monitoring-ingress
+      product: grafana
+      
+    hosts:
+      - grafana.monitoring.example.com
+      
+    tls:
+      - secretName: wildcard.monitoring.example.com
+        hosts:
+          - grafana.monitoring.example.com
+```
+
+The labels are optional and the hostname and secret name align with the current deployment of forgeops with cert-manager.
 
 
 

--- a/samples/config/prometheus-values/shared-cluster.yaml
+++ b/samples/config/prometheus-values/shared-cluster.yaml
@@ -1,3 +1,23 @@
+grafana:
+  ingress:
+    enabled: true
+
+    annotations: 
+      kubernetes.io/ingress.class: nginx
+      kubernetes.io/tls-acme: "true"
+
+    labels:
+      group: monitoring-ingress
+      product: grafana
+      
+    hosts:
+      - grafana.monitoring.forgeops.com
+      
+    tls:
+      - secretName: wildcard.monitoring.forgeops.com
+        hosts:
+          - grafana.monitoring.forgeops.com
+
 alertmanager:
   ## Alertmanager configuration directives
   ## Ref: https://prometheus.io/docs/alerting/configuration/
@@ -25,3 +45,42 @@ alertmanager:
       slack_configs:
       - channel: '#alerts-shared-cluster'
         text: "Namespace: {{ .GroupLabels.namespace }}\nSummary: {{ .CommonAnnotations.summary }}\nDescription: {{ .CommonAnnotations.description }}"
+
+  ingress:
+    enabled: true
+
+    annotations: 
+      kubernetes.io/ingress.class: nginx
+      kubernetes.io/tls-acme: "true"
+
+    labels:
+      group: monitoring-ingress
+      product: alertmanager
+      
+    hosts:
+      - alertmanager.monitoring.forgeops.com
+      
+    tls:
+      - secretName: wildcard.monitoring.forgeops.com
+        hosts:
+          - alertmanager.monitoring.forgeops.com
+          
+prometheus:
+  ingress:
+    enabled: true
+
+    annotations:
+      kubernetes.io/ingress.class: nginx
+      kubernetes.io/tls-acme: "true"
+
+    labels:
+      group: monitoring-ingress
+      product: prometheus
+
+    hosts:
+      - prometheus.monitoring.forgeops.com
+
+    tls:
+      - secretName: wildcard.monitoring.forgeops.com
+        hosts:
+          - prometheus.monitoring.forgeops.com 

--- a/samples/config/prometheus-values/shared-cluster.yaml
+++ b/samples/config/prometheus-values/shared-cluster.yaml
@@ -1,3 +1,6 @@
+# tls domain if ingress enabled
+domain: .forgeops.com
+
 grafana:
   ingress:
     enabled: true


### PR DESCRIPTION
Configuration to expose Prometheus, Grafana and Alertmanager externally.

The shared-cluster configuration values in samples/config/promtheus-values/shared-cluster.yaml has been updated to expose monitoring on forgeops domain.  (see the ingress endpoints in eng-shared).

@wajihahmed - You may want to adapt these for CDM. We can look at that separately.
@dgoldssfo - I've updated the forgerock-metrics readme but not sure if there's anything you want to add in the docs regarding this.