### PR TITLE
Client credential flow and user_admin scope support

### DIFF
--- a/samples/fr-platform/amster/config/realms/root/OAuth2Provider.json
+++ b/samples/fr-platform/amster/config/realms/root/OAuth2Provider.json
@@ -50,7 +50,7 @@
       "claimsParameterSupported" : false,
       "amrMappings" : { },
       "requireRequestUriRegistration" : false,
-      "alwaysAddClaimsToToken" : false,
+      "alwaysAddClaimsToToken" : true,
       "supportedRequestParameterEncryptionAlgorithms" : [ "RSA-OAEP", "RSA-OAEP-256", "A128KW", "RSA1_5", "A256KW", "dir", "A192KW" ],
       "authorisedOpenIdConnectSSOClients" : [ ],
       "idTokenInfoClientAuthenticationEnabled" : true,

--- a/samples/fr-platform/rs/config/routes/user_admin.json
+++ b/samples/fr-platform/rs/config/routes/user_admin.json
@@ -1,0 +1,32 @@
+{
+    "name": "user_admin",
+    "baseURI": "https://idm-service.sample.svc.cluster.local:8444",
+    "condition": "${matches(request.uri.path, '^/openidm/managed/user($|(/.+$))') or matches(request.uri.path, '^/openidm/policy/managed/user($|(/.+$))')}",
+    "handler": {
+        "type": "Chain",
+        "config": {
+            "filters": [
+                {
+                    "type": "OAuth2ResourceServerFilter",
+                    "config": {
+                        "scopes": [
+                            "user_admin"
+                        ],
+                        "requireHttps": false,
+                        "accessTokenResolver": "AccessTokenResolver",
+                        "cacheExpiration": "2 minutes"
+                    }
+                },
+                {
+                    "name": "SetTrustedAttributeHeaders",
+                    "type": "ScriptableFilter",
+                    "config": {
+                        "type": "application/x-groovy",
+                        "file": "constructSecurityContextHeaders.groovy"
+                    }
+                }
+            ],
+            "handler": "IDMClient"
+        }
+    }
+}

--- a/samples/fr-platform/rs/scripts/groovy/constructSecurityContextHeaders.groovy
+++ b/samples/fr-platform/rs/scripts/groovy/constructSecurityContextHeaders.groovy
@@ -16,4 +16,15 @@ if (sub.toLowerCase() == 'amadmin') {
     request.getHeaders().add('X-Authorization-Map', adminContext)
 }
 
+// The client will be the subject when using client credential flow
+if (contexts.oauth2.accessToken.info.client_id == contexts.oauth2.accessToken.info.sub) {
+    request.getHeaders().add('X-Authorization-Map', (new groovy.json.JsonBuilder([
+        "id" : contexts.oauth2.accessToken.info.client_id,
+        "component" : "endpoint/static/user",
+        "roles" : ["openidm-admin", "openidm-authorized"],
+        "moduleId" : "STATIC_USER"
+    ])).toString())
+}
+
+
 return next.handle(context, request)


### PR DESCRIPTION
This change allows clients which use the client credential grant type, as well as support for a new scope - "user_admin" - which exposes general access to managed/user data.