### PR TITLE
add ingress path for openam with rewrite annotation

### DIFF
--- a/helm/openam/templates/ingress.yaml
+++ b/helm/openam/templates/ingress.yaml
@@ -29,4 +29,11 @@ spec:
           backend:
             serviceName: {{ .Values.service.name }}
             servicePort: {{ .Values.service.externalPort }}
+      http:
+        paths:
+        - path: /openam
+          backend:
+            serviceName: {{ .Values.service.name }}
+            servicePort: {{ .Values.service.externalPort }}
+
 {{- end -}}

--- a/helm/openam/values.yaml
+++ b/helm/openam/values.yaml
@@ -95,6 +95,7 @@ ingress:
     nginx.ingress.kubernetes.io/cors-allow-headers: "authorization,x-requested-with"
     nginx.ingress.kubernetes.io/cors-allow-credentials: "false"
     nginx.ingress.kubernetes.io/cors-max-age: "600"
+    nginx.ingress.kubernetes.io/rewrite-target: "/"
 
 # Audit log details for log streaming sidecar containers.
 # AM can now stream audit logs to stdout. This option may be removed in the future.


### PR DESCRIPTION
add openam path into ingress with annotation to rewrite to root context. This gets around limitations with agents where you have to define a path. It doesn't impact the current process.