### PR TITLE
Fixed wrong log output in gatling script

### DIFF
--- a/helm/gatling-benchmark/get-logs.sh
+++ b/helm/gatling-benchmark/get-logs.sh
@@ -2,6 +2,5 @@
 # Utility to see logs from gatling init container when tests are running
 POD_NAME=$(kubectl get pod --selector=app=forgeops-benchmark \
   -o jsonpath='{.items[*].metadata.name}')
-CONTAINER_NAME=$(kubectl get pod --selector=app=forgeops-benchmark \
-  -o jsonpath='{.items[*].spec.initContainers[*].name}')
+CONTAINER_NAME=forgeops-benchmark-gatling
 kubectl logs -f $POD_NAME -c $CONTAINER_NAME


### PR DESCRIPTION
Fixed a problem with get-logs.sh script in gatling helm chart. 