### PR TITLE
Fixed oauth2 code regex

### DIFF
--- a/cicd/forgeops-tests/tests/smoke/am/AMSmoke.py
+++ b/cicd/forgeops-tests/tests/smoke/am/AMSmoke.py
@@ -80,7 +80,7 @@ class AMSmoke(unittest.TestCase):
         self.assertEqual(302, resp.status_code, 'Oauth2 authz REST')
 
         location = resp.headers['Location']
-        auth_code = re.findall('(?<=code=)(\w*)', location)
+        auth_code = re.findall('(?<=code=)(.+?)(?=&)', location)
 
         data = (('grant_type', 'authorization_code'),
                 ('code', auth_code[0]),


### PR DESCRIPTION
Regex was missing a couple of characters - random oauth2 flow failures. 