### PR TITLE
Cloud 370 ig monitoring auth

### DIFF
--- a/helm/forgerock-metrics/templates/am.yaml
+++ b/helm/forgerock-metrics/templates/am.yaml
@@ -48,7 +48,7 @@ kind: Secret
 metadata:
   name: prometheus-am
 data:
-  user: {{ .Values.am.secretUser }}
-  password: {{ .Values.am.secretPassword }}
+  user: {{ .Values.am.secretUser | b64enc }}
+  password: {{ .Values.am.secretPassword | b64enc }}
 type: Opaque
 {{- end -}}

--- a/helm/forgerock-metrics/templates/ds.yaml
+++ b/helm/forgerock-metrics/templates/ds.yaml
@@ -48,7 +48,7 @@ kind: Secret
 metadata:
   name: prometheus-ds
 data:
-  user: {{ .Values.ds.secretUser }}
-  password: {{ .Values.ds.secretPassword }}
+  user: {{ .Values.ds.secretUser | b64enc }}
+  password: {{ .Values.ds.secretPassword | b64enc }}
 type: Opaque
 {{- end -}}

--- a/helm/forgerock-metrics/templates/idm.yaml
+++ b/helm/forgerock-metrics/templates/idm.yaml
@@ -46,7 +46,7 @@ kind: Secret
 metadata:
   name: prometheus-idm
 data:
-  user:  {{ .Values.idm.secretUser }}
-  password: {{ .Values.idm.secretPassword }}
+  user:  {{ .Values.idm.secretUser | b64enc }}
+  password: {{ .Values.idm.secretPassword | b64enc }}
 type: Opaque
 {{- end -}}

--- a/helm/forgerock-metrics/templates/ig.yaml
+++ b/helm/forgerock-metrics/templates/ig.yaml
@@ -22,6 +22,13 @@ spec:
   # targetPort is the pod port *NOT* the service port
   - targetPort: 8080
     path: {{ .Values.ig.path }}
+    basicAuth:
+      password:
+        name: prometheus-ig
+        key: password
+      username:
+        name: prometheus-ig
+        key: user
   # This targets the service using a label.
   selector:
     matchLabels:

--- a/helm/forgerock-metrics/templates/ig.yaml
+++ b/helm/forgerock-metrics/templates/ig.yaml
@@ -48,7 +48,7 @@ kind: Secret
 metadata:
   name: prometheus-ig
 data:
-  user: {{ .Values.ig.secretUser }}
-  password: {{ .Values.ig.secretPassword }}
+  user: {{ .Values.ig.secretUser | b64enc }}
+  password: {{ .Values.ig.secretPassword | b64enc }}
 type: Opaque
 {{- end -}}

--- a/helm/forgerock-metrics/values.yaml
+++ b/helm/forgerock-metrics/values.yaml
@@ -18,32 +18,32 @@ am:
   enabled: true
   path: /json/metrics/prometheus
   labelSelectorComponent: openam
-  secretUser: cHJvbWV0aGV1cw==
-  secretPassword: cHJvbWV0aGV1cw==
+  secretUser: prometheus
+  secretPassword: prometheus
 
 ds:
   component: ds
   enabled: true
   path: /metrics/prometheus
   labelSelectorComponent: ds
-  secretUser: bW9uaXRvcg==
-  secretPassword: cGFzc3dvcmQ=
+  secretUser: monitor
+  secretPassword: password
 
 idm:
   component: idm
   enabled: true
   path: /openidm/metrics/prometheus
   labelSelectorComponent: openidm
-  secretUser: cHJvbWV0aGV1cw==
-  secretPassword: cHJvbWV0aGV1cw==
+  secretUser: prometheus
+  secretPassword: prometheus
 
 ig:
   component: ig
   enabled: true
   path: /openig/metrics/prometheus
   labelSelectorComponent: openig
-  secretUser: bWV0cmlj
-  secretPassword: cGFzc3dvcmQ=
+  secretUser: metric
+  secretPassword: password
   
 additionalRulesLabels:
   prometheus: monitoring-kube-prometheus

--- a/helm/forgerock-metrics/values.yaml
+++ b/helm/forgerock-metrics/values.yaml
@@ -42,8 +42,8 @@ ig:
   enabled: true
   path: /openig/metrics/prometheus
   labelSelectorComponent: openig
-  secretUser: b3BlbmlkbS1hZG1pbg==
-  secretPassword: b3BlbmlkbS1hZG1pbg==
+  secretUser: cHJvbWV0aGV1cw==
+  secretPassword: cHJvbWV0aGV1cw==
   
 additionalRulesLabels:
   prometheus: monitoring-kube-prometheus

--- a/helm/forgerock-metrics/values.yaml
+++ b/helm/forgerock-metrics/values.yaml
@@ -42,8 +42,8 @@ ig:
   enabled: true
   path: /openig/metrics/prometheus
   labelSelectorComponent: openig
-  secretUser: cHJvbWV0aGV1cw==
-  secretPassword: cHJvbWV0aGV1cw==
+  secretUser: bWV0cmlj
+  secretPassword: cGFzc3dvcmQ=
   
 additionalRulesLabels:
   prometheus: monitoring-kube-prometheus


### PR DESCRIPTION
added basic auth to servicemonitor for IG.  This needs to be used with the metrics protection filter in IG config as configured in the default IG basic-sample admin.json.