### PR TITLE
Cloud 913 update amster with commons parameters

### DIFF
--- a/helm/amster/templates/config-map.yaml
+++ b/helm/amster/templates/config-map.yaml
@@ -40,3 +40,6 @@ data:
   FQDN: {{ template "fqdn" . }}
   PROMETHEUS_PASSWORD: "{{ .Values.prometheusPassword }}"
   AMADMIN_PASSWORD_HASHED: "{{ .Values.amadminPasswordHashed }}"
+  DOMAIN: {{ .Values.domain }}
+  COOKIE_DOMAIN: {{ .Values.cookieDomain }}
+  

--- a/samples/config/prod/m-cluster/amster.yaml
+++ b/samples/config/prod/m-cluster/amster.yaml
@@ -12,6 +12,7 @@ config:
 ctsStores: ctsstore-0.ctsstore:1389,ctsstore-1.ctsstore:1389
 ctsPassword: password
 
+cookieDomain: forgeops.com
 
 # For production set CPU limits to help Kube Schedule the pods.
 resources:

--- a/samples/config/prod/s-cluster/amster.yaml
+++ b/samples/config/prod/s-cluster/amster.yaml
@@ -11,6 +11,7 @@ config:
 ctsStores: ctsstore-0.ctsstore:1389,ctsstore-1.ctsstore:1389
 ctsPassword: password
 
+cookieDomain: forgeops.com
 
 # For production set CPU limits to help Kube Schedule the pods.
 resources:


### PR DESCRIPTION
I've added a couple of extra commons parameters to amster configmap as part of updating CDM AM configuration with IG integration.