### PR TITLE
Make securityContext configurable

### DIFF
--- a/helm/apache-agent/templates/deployment.yaml
+++ b/helm/apache-agent/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args: ["install"]
         securityContext:
-          privileged: true
+{{ toYaml .Values.securityContext | indent 8 }}
         volumeMounts:
         - name: logs
           mountPath: /logmount

--- a/helm/apache-agent/values.yaml
+++ b/helm/apache-agent/values.yaml
@@ -23,3 +23,6 @@ service:
   type: ClusterIP
   externalPort: 80
   internalPort: 80
+
+securityContext:
+  privileged: true

--- a/helm/ds/templates/ds.yaml
+++ b/helm/ds/templates/ds.yaml
@@ -63,9 +63,7 @@ spec:
       terminationGracePeriodSeconds: 30
       # This will make sure the mounted PVCs are writable by the forgerock user with gid 111111.
       securityContext:
-        runAsUser: 11111
-        fsGroup: 11111
-        supplementalGroups: [ 0 ]
+{{ toYaml .Values.securityContext | indent 8 }}
       initContainers:
       {{ if .Values.restore.enabled }}
       - name: restore

--- a/helm/ds/values.yaml
+++ b/helm/ds/values.yaml
@@ -105,3 +105,8 @@ restore:
   # A backup folder contains a full backup and a number of incrementals. The most up to date incremental 
   # is used to recover.
   enabled: false
+
+securityContext:
+  runAsUser: 11111
+  fsGroup: 11111
+  supplementalGroups: [ 0 ]

--- a/helm/dsadmin/templates/dsadmin.yaml
+++ b/helm/dsadmin/templates/dsadmin.yaml
@@ -17,7 +17,7 @@ spec:
         app: dsadmin
     spec:
       securityContext:
-        fsGroup: 11111
+{{ toYaml .Values.securityContext | indent 8 }}
       initContainers:
       # When the NFS share has just been created it is owned by root. We need to run as root, create
       # a top level folder for backups, and chown the permisions to the forgerock user.

--- a/helm/dsadmin/templates/verify-job.yaml
+++ b/helm/dsadmin/templates/verify-job.yaml
@@ -25,7 +25,7 @@ spec:
         spec:
           # This will make sure the mounted PVCs are writable by the forgerock user with gid 111111.
           securityContext:
-            fsGroup: 11111
+{{ toYaml .Values.securityContext | indent 8 }}
           restartPolicy: Never      
           containers:
           - name: opendj

--- a/helm/dsadmin/values.yaml
+++ b/helm/dsadmin/values.yaml
@@ -44,4 +44,5 @@ nfs:
 # If you don't have slack, set this to "undefined"
 slackUrl: undefined
 
-
+securityContext:
+  fsGroup: 11111

--- a/helm/nginx-agent/templates/deployment.yaml
+++ b/helm/nginx-agent/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args: ["install"]
         securityContext:
-          privileged: true
+{{ toYaml .Values.securityContext | indent 8 }}
         volumeMounts:
         - name: logs
           mountPath: /logmount

--- a/helm/nginx-agent/values.yaml
+++ b/helm/nginx-agent/values.yaml
@@ -31,3 +31,6 @@ image:
   repository: forgerock-docker-public.bintray.io
   tag: latest
   pullPolicy: Always
+
+securityContext:
+  privileged: true


### PR DESCRIPTION
To run pods on OpenShift they need different security contexts. With
this it's possible to overwrite the default ones in a values file.