### PR TITLE
We don't need a seperate "cookieDomain" as we already have "domain". …

### DIFF
--- a/helm/amster/templates/config-map.yaml
+++ b/helm/amster/templates/config-map.yaml
@@ -41,5 +41,5 @@ data:
   PROMETHEUS_PASSWORD: "{{ .Values.prometheusPassword }}"
   AMADMIN_PASSWORD_HASHED: "{{ .Values.amadminPasswordHashed }}"
   DOMAIN: {{ .Values.domain }}
-  COOKIE_DOMAIN: {{ .Values.cookieDomain }}
+  COOKIE_DOMAIN: {{ .Values.domain }}
   

--- a/samples/config/prod/m-cluster/amster.yaml
+++ b/samples/config/prod/m-cluster/amster.yaml
@@ -12,8 +12,6 @@ config:
 ctsStores: ctsstore-0.ctsstore:1389,ctsstore-1.ctsstore:1389
 ctsPassword: password
 
-cookieDomain: forgeops.com
-
 # For production set CPU limits to help Kube Schedule the pods.
 resources:
  limits:

--- a/samples/config/prod/s-cluster/amster.yaml
+++ b/samples/config/prod/s-cluster/amster.yaml
@@ -11,8 +11,6 @@ config:
 ctsStores: ctsstore-0.ctsstore:1389,ctsstore-1.ctsstore:1389
 ctsPassword: password
 
-cookieDomain: forgeops.com
-
 # For production set CPU limits to help Kube Schedule the pods.
 resources:
  limits:


### PR DESCRIPTION
… Hence also removing it from the corresponding amster.yaml in CDM.