### PR TITLE
(EKS) Hard coding the image.tag for now to avoid load balancing issues…

### DIFF
--- a/bin/eks-create-ingress-cntlr.sh
+++ b/bin/eks-create-ingress-cntlr.sh
@@ -22,6 +22,7 @@ helm install --namespace nginx --name nginx \
   --set controller.stats.enabled=true \
   --set controller.service.externalTrafficPolicy=Local \
   --set controller.service.type=LoadBalancer \
+  --set controller.image.tag="0.21.0" \
   --set controller.service.annotations."service\.beta\.kubernetes\.io/aws-load-balancer-type"="nlb" \
   stable/nginx-ingress
 


### PR DESCRIPTION
…s. Sometime in future this shold be taken out once default version is 0.21.0 or greater.