### PR TITLE
Amster userstore configuration

### DIFF
--- a/helm/amster/templates/config-map.yaml
+++ b/helm/amster/templates/config-map.yaml
@@ -12,9 +12,15 @@ data:
     --cfgStore {{ .Values.configStore.type }} \
     {{ if eq .Values.configStore.type "dirServer" -}}
     --cfgStoreHost {{.Values.configStore.host }} \
-    --cfgStoreDirMgrPwd {{.Values.configStore.password }}  \
-    --cfgStorePort {{.Values.configStore.port }}  \
+    --cfgStoreDirMgrPwd {{.Values.configStore.password }} \
+    --cfgStorePort {{.Values.configStore.port }} \
     --cfgStoreRootSuffix {{ .Values.configStore.suffix }} \
+    --userStoreDirMgr "{{ .Values.userStore.dirManager }}" \
+    --userStoreDirMgrPwd  {{ .Values.userStore.password }} \
+    --userStoreHost {{ .Values.userStore.host }} \
+    --userStorePort {{ .Values.userStore.port }} \
+    --userStoreRootSuffix {{ .Values.userStore.suffix }} \
+    --userStoreType {{ .Values.userStore.storeType }} \
     {{ end -}}
     --policyAgentPwd {{ .Values.policyAgentPassword }}  \
     --pwdEncKey {{ .Values.encryptionKey }} \

--- a/helm/amster/values.yaml
+++ b/helm/amster/values.yaml
@@ -60,6 +60,18 @@ configStore:
   adminPort: 4444
   password: password
 
+# By default, userstore points to configstore - which is default
+# place for users when empty-import config is used. 
+userStore:
+  suffix: "ou=identities"
+  # If userstore is deployed as well but empty import configuration 
+  # is used, override this to userstore-0.userstore to use that store
+  host: configstore-0.configstore
+  port: 1389
+  dirManager: "cn=Directory manager"
+  password: "password"
+  storeType: "LDAPv3ForOpenDS"
+
 # determines if '--clean true' is used for the import-config.
 # suggest this is 'true' if importing a complete configuration
 # and set to 'false' if importing partial/incremental configurations


### PR DESCRIPTION
**Reason:**
People using empty import(empty import is used in docs as well) are currently having issues to create test user because there is wrong suffix passed (ou=am-config). To avoid this, we can define userstore config with amster and pass values from yaml files. 
**Problems:** 
Almost all our current configs(forgeops-init) have id=embedded for userstores and we are not using amster --clean import by default. Using this will now result in having two userstore defined (OpenDJ & embedded)
**Possible solutions to this:**
 - Remove userstore config from all of our configs and define userstore in helm chart
 - Rename existing userstore configs to use id=opendj & filename OpenDJ.json 

I've tested this with empty import as well as existing configs (smoke-tests)

We decided to let this PR on hold until we make 6.5.0 release. 