### PR TITLE
Ig smoke tests imp

### DIFF
--- a/cicd/forgeops-tests/config/ProductConfig.py
+++ b/cicd/forgeops-tests/config/ProductConfig.py
@@ -76,7 +76,7 @@ class IGConfig(object):
         try:
             self.ig_url = os.environ['IG_URL']
         except KeyError:
-            self.ig_url = 'https://openig.smoke.forgeops.com/'
+            self.ig_url = 'https://openig.smoke.forgeops.com'
         self.ssl_verify = SSL_VERIFY
 
 

--- a/cicd/forgeops-tests/tests/smoke/ig/IGSmoke.py
+++ b/cicd/forgeops-tests/tests/smoke/ig/IGSmoke.py
@@ -46,12 +46,31 @@ class IGSmoke(unittest.TestCase):
         resp = post(verify=self.amcfg.ssl_verify, url=self.amcfg.rest_oauth2_access_token_url,
                     auth=('oauth2', 'password'), data=data)
         access_token = resp.json()['access_token']
-
         header = {'Authorization': 'Bearer ' + access_token}
 
         resp = post(verify=self.igcfg.ssl_verify, url=self.igcfg.ig_url + '/rs-tokeninfo', headers=header)
         self.assertTrue(str(resp.content).__contains__('access_token='+access_token),
                         'Check if IG page contains access token and info')
+
+    def test_oauth2_tokenintrospect(self):
+        """Test to check oauth2 token from AM"""
+
+        data = {
+            'grant_type': 'password',
+            'username': 'igtestuser',
+            'password': 'password',
+            'scope': 'mail employeenumber'
+        }
+        resp = post(verify=self.amcfg.ssl_verify, url=self.amcfg.rest_oauth2_access_token_url,
+                    auth=('oauth2', 'password'), data=data)
+        access_token = resp.json()['access_token']
+
+        header = {'Authorization': 'Bearer ' + access_token}
+
+        resp = post(verify=self.igcfg.ssl_verify, url=self.igcfg.ig_url + '/rs-tokenintrospect', headers=header)
+        self.assertEquals(resp.status_code, 200, 'Get HTTP-200 on introspect endpoint')
+        self.assertTrue(str(resp.content).__contains__('user_id=igtestuser'), 'Expecting username on page')
+        self.assertTrue(str(resp.content).__contains__('client_id=oauth2'), 'Expecting client to be oauth2')
 
     def tearDown(self):
         """Remove user from AM"""

--- a/cicd/forgeops-tests/tests/smoke/ig/IGSmoke.py
+++ b/cicd/forgeops-tests/tests/smoke/ig/IGSmoke.py
@@ -2,15 +2,68 @@
 Initial smoke tests for IG deployment
 """
 import unittest
-from requests import get
+from requests import get, post, delete
+from requests.auth import HTTPBasicAuth
 
-from config.ProductConfig import IGConfig
+from config.ProductConfig import IGConfig, AMConfig
 
 
 class IGSmoke(unittest.TestCase):
     igcfg = IGConfig()
+    amcfg = AMConfig()
 
-    def test_ping(self):
-        """Test to check if we get to IG landing page"""
+    def setUp(self):
+        """Create user in AM to be used for testing"""
+        headers = {'X-OpenAM-Username': 'amadmin', 'X-OpenAM-Password': 'password',
+                   'Content-Type': 'application/json', 'Accept-API-Version': 'resource=2.0, protocol=1.0'}
+        resp = post(verify=self.amcfg.ssl_verify, url=self.amcfg.rest_authn_url, headers=headers)
+        self.assertEqual(200, resp.status_code, 'Admin login')
+        admin_token = resp.json()["tokenId"]
+
+        headers = {'iPlanetDirectoryPro': admin_token, 'Content-Type': 'application/json',
+                   'Accept-API-Version': 'resource=3.0, protocol=2.1'}
+        user_data = {'username': 'igtestuser',
+                     'userpassword': 'password',
+                     'mail': 'testuser@forgerock.com'}
+        resp = post(verify=self.amcfg.ssl_verify, url=self.amcfg.am_url + '/json/realms/root/users/?_action=create',
+                    headers=headers, json=user_data)
+        self.assertEqual(201, resp.status_code, "Expecting test user to be created - HTTP-201")
+
+    def test_reverse_proxy(self):
+        """Test to check if we get to web page via IG reverse proxy"""
         resp = get(verify=self.igcfg.ssl_verify, url=self.igcfg.ig_url)
-        self.assertEqual(200, resp.status_code, "IG landing page")
+        self.assertEqual(200, resp.status_code, "IG reverse proxy access")
+
+    def test_oauth2_tokeninfo(self):
+        """Test to check oauth2 token from AM"""
+
+        data = {
+            'grant_type': 'password',
+            'username': 'igtestuser',
+            'password': 'password',
+            'scope': 'mail employeenumber'
+        }
+        resp = post(verify=self.amcfg.ssl_verify, url=self.amcfg.rest_oauth2_access_token_url,
+                    auth=('oauth2', 'password'), data=data)
+        access_token = resp.json()['access_token']
+
+        header = {'Authorization': 'Bearer ' + access_token}
+
+        resp = post(verify=self.igcfg.ssl_verify, url=self.igcfg.ig_url + '/rs-tokeninfo', headers=header)
+        self.assertTrue(str(resp.content).__contains__('access_token='+access_token),
+                        'Check if IG page contains access token and info')
+
+    def tearDown(self):
+        """Remove user from AM"""
+        headers = {'X-OpenAM-Username': 'amadmin', 'X-OpenAM-Password': 'password',
+                   'Content-Type': 'application/json', 'Accept-API-Version': 'resource=2.0, protocol=1.0'}
+        resp = post(verify=self.amcfg.ssl_verify,  url=self.amcfg.rest_authn_url, headers=headers)
+        self.assertEqual(200, resp.status_code, 'Admin login')
+        admin_token = resp.json()["tokenId"]
+
+        headers = {'iPlanetDirectoryPro': admin_token, 'Content-Type': 'application/json',
+                   'Accept-API-Version': 'resource=3.0, protocol=2.1'}
+
+        resp = delete(verify=self.amcfg.ssl_verify, url=self.amcfg.am_url + '/json/realms/root/users/igtestuser',
+                      headers=headers)
+        self.assertEqual(200, resp.status_code, "Expecting test user to be deleted - HTTP-200")

--- a/samples/config/smoke-deployment/env.sh
+++ b/samples/config/smoke-deployment/env.sh
@@ -8,4 +8,4 @@ DOMAIN="forgeops.com"
 
 # The components to deploy
 # Note the opendj stores are aliased as configstore, userstore, ctstore - but they all use the ds helm chart.
-COMPONENTS=(frconfig configstore userstore ctsstore openam amster postgres-openidm openig openidm apache-agent nginx-agent)
+COMPONENTS=(frconfig configstore userstore ctsstore openam amster postgres-openidm openig openidm web )

--- a/samples/config/smoke-deployment/frconfig.yaml
+++ b/samples/config/smoke-deployment/frconfig.yaml
@@ -1,5 +1,5 @@
 git:
-  repo: https://github.com/ForgeRock/forgeops-init.git
+  repo: https://github.com/Forgerock/forgeops-init.git
   branch: master
 
 

--- a/samples/config/smoke-deployment/openig.yaml
+++ b/samples/config/smoke-deployment/openig.yaml
@@ -1,3 +1,5 @@
 # image:
 #   pullPolicy: Always
 #   tag: latest
+config:
+  path: /git/config/6.5/smoke-tests/ig/


### PR DESCRIPTION
Jira issue? CLOUD-903
Release 6.5.0 backport required? No
6.5.0 doc changes needed? No
7.0.0 doc changes needed? No
Required README updates made? No

Added tests for IG based on m-cluster configuration. Using rs-tokeninfo and rs-tokenintrospect endpoints defined in IG configuration. 

This is integration test between IG and AM