### PR TITLE
Added -I switch to download script

### DIFF
--- a/docker/downloader/download
+++ b/docker/downloader/download
@@ -7,6 +7,18 @@
 
 API_KEY=${API_KEY:-`cat /api_key`}
 
+
+VERSION=${VERSION:-6.5.0}
+
+# Internal -  for milestone releases
+INTERNAL_REPO=https://maven.forgerock.org/repo/internal-releases/org/forgerock
+
+# Private releases - includes only released products
+PRIVATE_REPO=https://maven.forgerock.org/repo/private-releases/org/forgerock
+
+# Default to private (release) repo
+REPO=$PRIVATE_REPO
+
 # Pass this in via the environment to use a GCS cache for the artifacts. You must have RW access to this bucket
 #GCS_DIR=gs://forgeops-cache
 
@@ -68,7 +80,7 @@ dl(){
 
     if [ -z "${WGET+x}" ]
     then
-        curl --fail -s -H "$HEADER"  $src -o $3
+        curl -v --fail -s -H "$HEADER"  $src -o $3
     else
         wget -q --inet4-only --timeout=20 --header "$HEADER" -O $3 $src
     fi
@@ -86,13 +98,9 @@ dl(){
 
 }
 
-VERSION=${VERSION:-6.5.0}
-# you should not need to edit the paths below
-REPO=https://maven.forgerock.org/repo/internal-releases/org/forgerock
-
-
-while getopts "wv:" opt; do
+while getopts "Iwv:" opt; do
   case ${opt} in
+    I ) REPO=$INTERNAL_REPO ;;
     w ) WGET="true" ;;
     v ) VERSION="${OPTARG}" 
         echo $VERSION | grep SNAPSHOT \
@@ -100,8 +108,9 @@ while getopts "wv:" opt; do
                 SNAPSHOT="true"
         ;;
     \? )
-         echo "Usage: dl.sh [-v version] images..."
+         echo "Usage: download [-I] [-v version] images..."
          echo "-c Use curl instead of wget"
+         echo "-I Use the internal repo for milestones"
          echo "-v VERSION - download a specific version (example -v 6.5.0). Default $VERSION"
          echo "Images can be one or more of: $IMAGES"
          echo "If not specified, all images are downloaded"

--- a/docker/downloader/download
+++ b/docker/downloader/download
@@ -80,7 +80,7 @@ dl(){
 
     if [ -z "${WGET+x}" ]
     then
-        curl -v --fail -s -H "$HEADER"  $src -o $3
+        curl --fail -s -H "$HEADER"  $src -o $3
     else
         wget -q --inet4-only --timeout=20 --header "$HEADER" -O $3 $src
     fi


### PR DESCRIPTION
Added -I switch to download script to switch between the private releases (customer) and internal repos.

The default is private (customer)

Closes https://github.com/ForgeRock/forgeops/issues/471 
Release 6.5.0 backport required? yes
6.5.0 doc changes needed? no
7.0.0 doc changes needed? no
