### PR TITLE
forgeops: turn off green color at prompt after deploy.sh finishes

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -323,4 +323,4 @@ echo ""
 echo "=> For each directory pod you want to backup execute the following command"
 echo "   $ kubectl exec -it <podname> scripts/schedule-backup.sh"
 
-printf "\e[38;5;40m=======> Deployment is ready <========\n"
+printf "\e[38;5;40m=======> Deployment is ready <========\e[m\n"


### PR DESCRIPTION
My first PR to forgeops, so starting with a simple one.

Turning off the green prompt at the end of the deployment run.

Tom
