### PR TITLE
forgeops: convert uppercase usernames to allow GKE cluster creation

### DIFF
--- a/bin/gke-create-cluster.sh
+++ b/bin/gke-create-cluster.sh
@@ -37,7 +37,7 @@ esac
 # Who created this cluster.
 CREATOR="${USER:-unknown}"
 # Labels can not contain dots that may be present in the user.name
-CREATOR=$(echo $CREATOR | sed 's/\./_/')
+CREATOR=$(echo $CREATOR | sed 's/\./_/' | tr "[:upper:]" "[:lower:]")
 
 
 echo ""


### PR DESCRIPTION
GKE cluster creation does not like usernames with an upper case letter, like on a Mac ...