### PR TITLE
forgeops: do not create forgerock home in ds Dockerfile as it already…

### DIFF
--- a/docker/ds/Dockerfile
+++ b/docker/ds/Dockerfile
@@ -28,7 +28,7 @@ RUN chmod +x /usr/bin/tini
 
 COPY --from=1 /var/tmp/bootstrap/run/dsrs1 /opt/opendj/
 
-RUN useradd -d /opt/opendj -G root -m -u 11111 forgerock \
+RUN useradd -d /opt/opendj -G root -u 11111 forgerock \
     && apt-get update && apt-get install -y --no-install-recommends dumb-init vim fio
    
 WORKDIR /opt/opendj 


### PR DESCRIPTION
During the ds docker image build, an error message occurs because /home/forgerock already exists at that point, so no need to create it again with useradd -m