### PR TITLE
forgeops: make git and util repos customizable

### DIFF
--- a/helm/amster/templates/amster.yaml
+++ b/helm/amster/templates/amster.yaml
@@ -24,8 +24,8 @@ spec:
       {{ if eq .Values.config.strategy "git" -}}
       initContainers:
       - name: git-init
-        image: forgerock-docker-public.bintray.io/forgerock/git:6.5.0
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        image: {{ .Values.gitImage.repository }}:{{ .Values.gitImage.tag }}
+        imagePullPolicy: {{ .Values.gitImage.pullPolicy }}
         volumeMounts:
         - name: git
           mountPath: /git
@@ -69,8 +69,8 @@ spec:
 {{ toYaml .Values.resources | indent 12 }}
       {{ if eq .Values.config.strategy "git" -}}
       - name: git
-        image: forgerock-docker-public.bintray.io/forgerock/git:6.5.0
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        image: {{ .Values.gitImage.repository }}:{{ .Values.gitImage.tag }}
+        imagePullPolicy: {{ .Values.gitImage.pullPolicy }}
         volumeMounts:
         - name: git
           mountPath: /git

--- a/helm/amster/values.yaml
+++ b/helm/amster/values.yaml
@@ -41,6 +41,11 @@ image:
   pullPolicy: IfNotPresent
   #pullPolicy: Always
 
+gitImage:
+  repository: forgerock-docker-public.bintray.io/forgerock/git
+  tag: 6.5.0
+  pullPolicy: IfNotPresent
+
 configStore:
   # type can be dirServer or embedded. Only dirServer is supported
   type: dirServer

--- a/helm/gatling-benchmark/templates/gatling.yaml
+++ b/helm/gatling-benchmark/templates/gatling.yaml
@@ -16,8 +16,8 @@ spec:
       initContainers:
       {{ if eq .Values.config.strategy  "git" }}
       - name: git-init
-        image: forgerock-docker-public.bintray.io/forgerock/git:6.5.0
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        image: {{ .Values.gitImage.repository }}:{{ .Values.gitImage.tag }}
+        imagePullPolicy: {{ .Values.gitImage.pullPolicy }}
         volumeMounts:
         - name: git
           mountPath: /git

--- a/helm/gatling-benchmark/values.yaml
+++ b/helm/gatling-benchmark/values.yaml
@@ -10,6 +10,11 @@ image:
   repository: forgerock-docker-public.bintray.io/forgerock/gatling:6.5.0
   pullPolicy: Always
   
+gitImage:
+  repository: forgerock-docker-public.bintray.io/forgerock/git
+  tag: 6.5.0
+  pullPolicy: IfNotPresent
+
 config:
   # Name of the configMap that holds the configuration repository URL and of
   # the secret required to access it.

--- a/helm/openam/templates/openam-deployment.yaml
+++ b/helm/openam/templates/openam-deployment.yaml
@@ -18,8 +18,8 @@ spec:
       initContainers:
        {{ if eq .Values.config.strategy  "git" }}
       - name: git-init
-        image: forgerock-docker-public.bintray.io/forgerock/git:6.5.0
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        image: {{ .Values.gitImage.repository }}:{{ .Values.gitImage.tag }}
+        imagePullPolicy: {{ .Values.gitImage.pullPolicy }}
         volumeMounts:
         - name: git
           mountPath: /git
@@ -32,12 +32,12 @@ spec:
       {{ end }}
       # The init containers below should be removed once file based configuration is in place.
       - name: wait-for-configstore
-        image: "forgerock-docker-public.bintray.io/forgerock/util:6.0.0"
-        imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+        image: {{ .Values.utilImage.repository }}:{{ .Values.utilImage.tag }}
+        imagePullPolicy: {{ .Values.utilImage.pullPolicy }}
         args: [ "wait", "{{ .Values.configLdapHost }}", "{{ .Values.configLdapPort }}" ]
       - name: bootstrap
-        image: forgerock-docker-public.bintray.io/forgerock/util:6.5.0
-        imagePullPolicy:  {{ .Values.image.pullPolicy }}
+        image: {{ .Values.utilImage.repository }}:{{ .Values.utilImage.tag }}
+        imagePullPolicy: {{ .Values.utilImage.pullPolicy }}
         env:
         - name: BASE_DN
           value: {{ .Values.rootSuffix }}

--- a/helm/openam/values.yaml
+++ b/helm/openam/values.yaml
@@ -10,6 +10,16 @@ image:
   # For development we set this to Always to get the most current image:
   pullPolicy: IfNotPresent
 
+gitImage:
+  repository: forgerock-docker-public.bintray.io/forgerock/git
+  tag: 6.5.0
+  pullPolicy: IfNotPresent
+
+utilImage:
+  repository: forgerock-docker-public.bintray.io/forgerock/util
+  tag: 6.5.0
+  pullPolicy: IfNotPresent
+
 domain: .example.com
 
 config:

--- a/helm/openidm/templates/_helpers.tpl
+++ b/helm/openidm/templates/_helpers.tpl
@@ -34,8 +34,8 @@ tls:
 {{- define "git-init" -}}
 {{ if eq .Values.config.strategy "git" }}
 - name: git-init
-  image: forgerock-docker-public.bintray.io/forgerock/git:6.5.0
-  imagePullPolicy: {{ .Values.image.pullPolicy }}
+  image: {{ .Values.gitImage.repository }}:{{ .Values.gitImage.tag }}
+  imagePullPolicy: {{ .Values.gitImage.pullPolicy }}
   volumeMounts:
   - name: git
     mountPath: /git
@@ -54,8 +54,8 @@ tls:
 {{- define "git-sync" -}}
 {{ if eq .Values.config.strategy "git" }}
 - name: git
-  image: forgerock/git:6.5.0
-  imagePullPolicy: {{ .Values.image.pullPolicy }}
+  image: {{ .Values.gitImage.repository }}:{{ .Values.gitImage.tag }}
+  imagePullPolicy: {{ .Values.gitImage.pullPolicy }}
   volumeMounts:
   - name: git
     mountPath: /git

--- a/helm/openidm/templates/idm.yaml
+++ b/helm/openidm/templates/idm.yaml
@@ -26,8 +26,8 @@ spec:
       {{ if eq .Values.config.strategy  "git" }}
       initContainers:
       - name: git-init
-        image: forgerock-docker-public.bintray.io/forgerock/git:6.5.0
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        image: {{ .Values.gitImage.repository }}:{{ .Values.gitImage.tag }}
+        imagePullPolicy: {{ .Values.gitImage.pullPolicy }}
         volumeMounts:
         - name: git
           mountPath: /git
@@ -96,8 +96,8 @@ spec:
           mountPath: /var/run/openidm/logging
       {{ if eq .Values.config.strategy  "git" }}
       - name: git
-        image: forgerock-docker-public.bintray.io/forgerock/git:6.5.0
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        image: {{ .Values.gitImage.repository }}:{{ .Values.gitImage.tag }}
+        imagePullPolicy: {{ .Values.gitImage.pullPolicy }}
         volumeMounts:
         - name: git
           mountPath: /git

--- a/helm/openidm/values.yaml
+++ b/helm/openidm/values.yaml
@@ -38,6 +38,11 @@ image:
   # For development use Always
   # pullPolicy: Always
 
+gitImage:
+  repository: forgerock-docker-public.bintray.io/forgerock/git
+  tag: 6.5.0
+  pullPolicy: IfNotPresent
+
 # override Java JVM options.
 # For JDK 11 add -XX:+IgnoreUnrecognizedVMOptions --add-opens=java.base/jdk.internal.loader=ALL-UNNAMED
 javaOpts: "-Xmx1024m -server -XX:+UseG1GC"

--- a/helm/openig/templates/deployment.yaml
+++ b/helm/openig/templates/deployment.yaml
@@ -23,7 +23,8 @@ spec:
       {{ if eq .Values.config.strategy  "git" }}
       initContainers:
       - name: git-init
-        image: forgerock-docker-public.bintray.io/forgerock/git:6.5.0
+        image: {{ .Values.gitImage.repository }}:{{ .Values.gitImage.tag }}
+        imagePullPolicy: {{ .Values.gitImage.pullPolicy }}
         volumeMounts:
         - name: git
           mountPath: /git

--- a/helm/openig/values.yaml
+++ b/helm/openig/values.yaml
@@ -31,6 +31,11 @@ image:
   tag: 6.5.0
   pullPolicy: IfNotPresent
 
+gitImage:
+  repository: forgerock-docker-public.bintray.io/forgerock/git
+  tag: 6.5.0
+  pullPolicy: IfNotPresent
+
 resources:
 #  limits:
 #    cpu: 1000m


### PR DESCRIPTION
Various helm charts have hardcoded repos for git and util docker images. Added variables to make them customizable, with defaults to the original forgerock repos.