### PR TITLE
Changing the "fast" storage class from io1 to gp2. 

### DIFF
--- a/bin/eks-create-sc.sh
+++ b/bin/eks-create-sc.sh
@@ -14,7 +14,7 @@
 # For io1 the maximum ratio of provisioned IOPS to requested volume size (in GiB) is 50:1.
 # For example, a 100 GiB volume can be provisioned with up to 5,000 IOPS.
 # Check this page out for more details https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html
-# For the "fast" sc, add "iopsPerGB" parameter if you want to specify IOPS for io1.
+
 
 kubectl create -f - <<EOF
 kind: StorageClass
@@ -23,8 +23,7 @@ metadata:
   name: fast
 provisioner: kubernetes.io/aws-ebs
 parameters:
-  type: io1
-  fstype: ext4
+  type: gp2
 ---
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
@@ -33,7 +32,19 @@ metadata:
 provisioner: kubernetes.io/aws-ebs
 parameters:
   type: gp2
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: fast10
+provisioner: kubernetes.io/aws-ebs
+parameters:
+  type: io1
+  fstype: ext4
+  iopsPerGB: "10"
 EOF
 
 
 kubectl patch storageclass standard -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
+
+


### PR DESCRIPTION
EJS io1 pricing was miscalculated initially and correct calculation reveals that cost is too prohibitive especially for the s and m clusters.  Recent testing has shown that gp2 (which is also based on SSD) performs quite good and the price is significantly lower than io1 as you don't have to pay separately for provisioned IOPS.  In other words the price to performance ratio of gp2 is very good.  Yet i am still adding a new storage class called "fast10" which is based on io1 and iopsPerGB set to 10.  This new storage class might be used in l-cluster and other extreme scenarios.

Release 6.5.0 backport required? YES
   -> Section of the docs that deal with creation of the Storage Class for EKS
6.5.0 doc changes needed? YES
7.0.0 doc changes needed? NA
Required README updates made? Maybe
