### PR TITLE
Backup only specific backends

### DIFF
--- a/docker/ds/scripts/backup.sh
+++ b/docker/ds/scripts/backup.sh
@@ -8,18 +8,35 @@ source /opt/opendj/env.sh
 
 #DATESTAMP=`date "+%Y/%m/%d"`
 
-mkdir -p "$BACKUP_DIRECTORY"
-chmod 775 "$BACKUP_DIRECTORY"
+mkdir -p "${BACKUP_DIRECTORY}"
+chmod 775 "${BACKUP_DIRECTORY}"
+
+IDS=()
+
+if [ "${DS_ENABLE_USERSTORE}" = "true" ]; then
+	IDS+=(" --backendId amIdentityStore")
+fi
+if [ "${DS_ENABLE_IDMREPO}" = "true" ]; then
+	IDS+=(" --backendId idmRepo")
+fi
+if [ "${DS_ENABLE_CONFIGSTORE}" = "true" ]; then
+	IDS+=(" --backendId cfgStore")
+fi
+if [ "${DS_ENABLE_CTS}" = "true" ]; then
+	IDS+=(" --backendId amCts")
+fi
+
+if [ ${#IDS[@]} -eq 0 ]; then
+	echo "Nothing to backup. Are any env var DS_ENABLE_* set?"
+	exit 0
+fi
 
 # If no full backup exists, the --incremental option will create one.
 echo "Starting backup to ${BACKUP_DIRECTORY}"
-/opt/opendj/bin/backup --backupDirectory "${BACKUP_DIRECTORY}" \
-  --hostname localhost \
-  -p 4444 -D "cn=Directory Manager" -j "${DIR_MANAGER_PW_FILE}" \
-  --compress \
-  --trustAll \
-  --backUpAll \
-  --incremental
-
-
-
+OPENDJ_JAVA_ARGS="-Xmx512m" /opt/opendj/bin/backup --hostname localhost --port 4444 \
+    --bindDn "cn=Directory Manager" --bindPasswordFile "${DIR_MANAGER_PW_FILE}" \
+    --backupDirectory "${BACKUP_DIRECTORY}" \
+    --compress \
+    --trustAll \
+    --incremental \
+    ${IDS[@]}


### PR DESCRIPTION
Now backup.sh backs up specific backends instead of backup up all backends.  The reason is that restoring all backends online is not possible which is what scripts/restore.sh does and hence it fails.

Specifically backup.sh now looks at the env vars DS_ENABLE_* and if the value is true adds the backend to the --backendId arg to the DS backup
binary. Hence the backendId are hard coded and if they change in future then this script will have to be modified.

Jira issue? NA
Release 6.5.0 backport required? NO
6.5.0 doc changes needed? NO
7.0.0 doc changes needed? YES
Required README updates made? NO
