### PR TITLE
Wait for port-forward to be ready to avoid random test failures

### DIFF
--- a/cicd/forgeops-tests/run-smoke-tests.sh
+++ b/cicd/forgeops-tests/run-smoke-tests.sh
@@ -3,5 +3,6 @@
 # Helper script for google cloud build to keep it simple to run tests
 # while having stdout in file to send to slack
 
+export PYTHONUNBUFFERED=x
 python3 forgeops-tests.py --suite tests/smoke/ &> res.txt
 tail -n 4 res.txt > results.txt


### PR DESCRIPTION
Jira issue? CLOUD-1018
Release 6.5.0 backport required? no
6.5.0 doc changes needed? no
7.0.0 doc changes needed?no
Required README updates made? no

- check that port-forward is ready before continuing the test
- set PYTHONUNBUFFERED before running the tests to have traces in correct order