### PR TITLE
Added a workaround for running multiple gatling sims

### DIFF
--- a/docker/gatling/custom-gatling.sh
+++ b/docker/gatling/custom-gatling.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Custom gatling runtime script
 # Useful for making it easier to pass arguments to gatling from helm charts
 #
@@ -45,7 +45,7 @@ echo "----------------------------"
 echo "Provided script parameters:"
 echo "java_options:${JAVA_OPTIONS}"
 echo "cmd_options:${CMD_OPTIONS}"
-echo "gatling_args:${GATLING_ARGS}"
+echo "tests to run: ${TESTS}"
 echo "----------------------------"
 echo ""
 echo "Starting gatling simulation"
@@ -62,9 +62,16 @@ then
     echo "----------------------------"
     sed -i -e "s/ io.gatling.app.Gatling/ ${CMD_OPTIONS} io.gatling.app.Gatling/g" /opt/gatling/bin/gatling.sh
 fi
-echo ""
-echo "----------------------------"
-echo "GATLING COMMAND: gatling.sh ${GATLING_ARGS}"
-echo "----------------------------"
+# Workaround for running multiple tests. A list of tests(whitespace separated string with test names) is parsed
+# and gatling is run multiple times
+for test in $TESTS; do 
+    RUN_ARG=$(sed "s/TESTNAME/$test/g" <<< ${GATLING_ARGS})
+    echo ""
+    echo "----------------------------"
+    echo "GATLING COMMAND: gatling.sh ${RUN_ARG}"
+    echo "----------------------------"
 
-gatling.sh ${GATLING_ARGS}
+    gatling.sh ${RUN_ARG}    
+done
+
+

--- a/helm/gatling-benchmark/templates/gatling.yaml
+++ b/helm/gatling-benchmark/templates/gatling.yaml
@@ -31,6 +31,9 @@ spec:
       - name: forgeops-benchmark-gatling
         image: {{ .Values.image.repository }}
         imagePullPolicy: Always
+        env:
+          - name: TESTS
+            value: {{ .Values.benchmark.testname }}
         command:
           - /bin/bash
           - -c
@@ -55,7 +58,7 @@ spec:
             -Doauth2_client_id={{ .Values.benchmark.oauth2_client_id }}
             -Doauth2_client_pw={{ .Values.benchmark.oauth2_client_pw }}
             '
-            -g '-m -s {{ .Values.benchmark.testname }} -rd {{ .Values.benchmark.testname }}' &&
+            -g '-m -s TESTNAME -rd TESTNAME' &&
             export FN=$(ls -t /opt/gatling/results | head -1) && tar -czvf /opt/gatling/results/$FN.tar.gz
             /opt/gatling/results/$FN
         volumeMounts:

--- a/helm/gatling-benchmark/values.yaml
+++ b/helm/gatling-benchmark/values.yaml
@@ -38,6 +38,9 @@ benchmark:
   #
   # For IG it is:
   # - ig.IGReverseProxyWebSim
+  # 
+  # To run multiple tests, syntax is as following:
+  # testname: "am.AMAccessTokenSim am.AMRestAuthNSim"
 
   testname: am.AMAccessTokenSim
   


### PR DESCRIPTION
Jira issue? CLOUD-995
Release 6.5.0 backport required? yes
6.5.0 doc changes needed? yes
7.0.0 doc changes needed? Not sure
Required README updates made? no

This is rather a quick workaround that should not change any functionality. It however add a possibility to run multiple tests in one pod - one after another. This is useful for tests that depends on previous test creation some sort of dependency (token files, etc...)