### PR TITLE
Apply fix for OPENAM-14170 - make sure tomcat reports correct port/sc…

### DIFF
--- a/docker/openam/server.xml
+++ b/docker/openam/server.xml
@@ -44,7 +44,9 @@
                SSLEnabled="false"
                connectionTimeout="20000"
                URIEncoding="UTF-8"
-               redirectPort="8443" />
+	       redirectPort="8443"
+               proxyPort="443"
+               scheme="https" />
 
       <!--  We terminate ssl externally
 


### PR DESCRIPTION
This should prevent the need for configuring the base url source service, as tomcat should always report the correct URL.

Jira issue? OPENAM-14170
Release 6.5.0 backport required? yes
6.5.0 doc changes needed? no
7.0.0 doc changes needed? no
Required README updates made? no
