### PR TITLE
CLOUD-1018 Test restructure. Move stop ds port forwarding.

### DIFF
--- a/cicd/forgeops-tests/config/ProductConfig.py
+++ b/cicd/forgeops-tests/config/ProductConfig.py
@@ -104,6 +104,13 @@ class DSConfig(object):
         self.ds1_rest_ping_url = self.ds1_url + '/alive'
         self.ssl_verify = SSL_VERIFY
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.stop_ds_port_forward(instance_nb=0)
+        self.stop_ds_port_forward(instance_nb=1)
+
     def stop_ds_port_forward(self, instance_nb=0):
         if not is_cluster_mode():
             eval('self.ds%s_popen' % instance_nb).kill()

--- a/cicd/forgeops-tests/tests/smoke/ds/DSSmoke.py
+++ b/cicd/forgeops-tests/tests/smoke/ds/DSSmoke.py
@@ -15,73 +15,68 @@ import logging
 # Framework imports
 from config.ProductConfig import DSConfig
 
-
-class DSSmoke(unittest.TestCase):
-    dscfg = DSConfig()
-
-    @classmethod
-    def tearDownClass(self):
-        """DSSmoke suite teardown"""
-        self.dscfg.stop_ds_port_forward(instance_nb=0)
-        self.dscfg.stop_ds_port_forward(instance_nb=1)
-
+class DSPing(unittest.TestCase):
     def test_0_ping(self):
         """Pings OpenDJ instances to see if servers are alive"""
-        response = get(verify=self.dscfg.ssl_verify, url=self.dscfg.ds0_rest_ping_url)
-        self.assertEqual(response.status_code, 200, 'userstore-0 is alive')
+        with DSConfig() as dscfg:
+            response = get(verify=dscfg.ssl_verify, url=dscfg.ds0_rest_ping_url)
+            self.assertEqual(response.status_code, 200, 'userstore-0 is alive')
 
-        response = get(verify=self.dscfg.ssl_verify, url=self.dscfg.ds1_rest_ping_url)
-        self.assertEqual(response.status_code, 200, 'userstore-1 is alive')
+            response = get(verify=dscfg.ssl_verify, url=dscfg.ds1_rest_ping_url)
+            self.assertEqual(response.status_code, 200, 'userstore-1 is alive')
 
+class DSResourceReplication(unittest.TestCase):
     def test_resource_replication(self):
         """Creates a new resource via rest2ldap interface and
            verifies it is replicated to the second instance.
            Ref:  https://ea.forgerock.com/docs/ds/rest-guide/create-rest.html#create-rest"""
 
-        headers = {'Content-Type': 'application/json',
-                   'If-None-Match': '*'
-                   }
+        with DSConfig() as dscfg:
+            headers = {'Content-Type': 'application/json',
+                       'If-None-Match': '*'
+                       }
 
-        json_data = {
-            "_id": "newuser_ds0",
-            "displayName": ["newuser_added_to_ds0"],
-            "contactInformation": {
-                "telephoneNumber": "+1 408 555 1212",
-                "emailAddress": "newuser_ds0@example.com"
-            },
-            "name": {
-                "familyName": "New",
-                "givenName": "UserDSZero"
-            },
-            "_schema": "frapi:opendj:rest2ldap:user:1.0"
-        }
+            json_data = {
+                "_id": "newuser_ds0",
+                "displayName": ["newuser_added_to_ds0"],
+                "contactInformation": {
+                    "telephoneNumber": "+1 408 555 1212",
+                    "emailAddress": "newuser_ds0@example.com"
+                },
+                "name": {
+                    "familyName": "New",
+                    "givenName": "UserDSZero"
+                },
+                "_schema": "frapi:opendj:rest2ldap:user:1.0"
+            }
 
-        logging.info("Creating a new user entry with ID newuser_ds0")
-        response = put(verify=self.dscfg.ssl_verify, url=self.dscfg.ds0_url + '/api/users/newuser_ds0',
-                   auth=('am-identity-bind-account', 'password'), headers=headers,json=json_data)
-        self.assertEqual(response.status_code, 201)
+            logging.info("Creating a new user entry with ID newuser_ds0")
+            response = put(verify=dscfg.ssl_verify, url=dscfg.ds0_url + '/api/users/newuser_ds0',
+                       auth=('am-identity-bind-account', 'password'), headers=headers,json=json_data)
+            self.assertEqual(response.status_code, 201)
 
-        logging.info("Verifying user entry with ID newuser_ds0 replicated in userstore-1")
-        response = get(verify=self.dscfg.ssl_verify, url=self.dscfg.ds1_url + '/api/users/newuser_ds0',
-                       auth=('am-identity-bind-account', 'password'))
-        self.assertEqual(response.status_code, 200)
+            logging.info("Verifying user entry with ID newuser_ds0 replicated in userstore-1")
+            response = get(verify=dscfg.ssl_verify, url=dscfg.ds1_url + '/api/users/newuser_ds0',
+                           auth=('am-identity-bind-account', 'password'))
+            self.assertEqual(response.status_code, 200)
 
     @classmethod
     def tearDownClass(self):
-        instance = DSSmoke()
         """Delete datastore resource from users/"""
+        with DSConfig() as dscfg:
+            instance = DSResourceReplication()
 
-        logging.info("Deleting user entry with ID newuser_ds0 from userstore-0")
-        response = delete(verify=self.dscfg.ssl_verify, url=self.dscfg.ds0_url + '/api/users/newuser_ds0',
-                          auth=('am-identity-bind-account', 'password'))
-        self.assertEqual(instance, response.status_code, 200)
+            logging.info("Deleting user entry with ID newuser_ds0 from userstore-0")
+            response = delete(verify=dscfg.ssl_verify, url=dscfg.ds0_url + '/api/users/newuser_ds0',
+                              auth=('am-identity-bind-account', 'password'))
+            self.assertEqual(instance, response.status_code, 200)
 
-        logging.info("Verifying user entry with ID newuser_ds0 has been deleted from userstore-0")
-        response = get(verify=self.dscfg.ssl_verify, url=self.dscfg.ds0_url + '/api/users/newuser_ds0',
-                       auth=('am-identity-bind-account', 'password'))
-        self.assertEqual(instance, response.status_code, 404)
+            logging.info("Verifying user entry with ID newuser_ds0 has been deleted from userstore-0")
+            response = get(verify=dscfg.ssl_verify, url=dscfg.ds0_url + '/api/users/newuser_ds0',
+                           auth=('am-identity-bind-account', 'password'))
+            self.assertEqual(instance, response.status_code, 404)
 
-        logging.info("Verifying user entry with ID newuser_ds0 has been deleted from userstore-1")
-        response = get(verify=self.dscfg.ssl_verify, url=self.dscfg.ds1_url + '/api/users/newuser_ds0',
-                       auth=('am-identity-bind-account', 'password'))
-        self.assertEqual(instance, response.status_code, 404)
+            logging.info("Verifying user entry with ID newuser_ds0 has been deleted from userstore-1")
+            response = get(verify=dscfg.ssl_verify, url=dscfg.ds1_url + '/api/users/newuser_ds0',
+                           auth=('am-identity-bind-account', 'password'))
+            self.assertEqual(instance, response.status_code, 404)


### PR DESCRIPTION
Jira issue? CLOUD-1018
Release 6.5.0 backport required? No
6.5.0 doc changes needed? No
7.0.0 doc changes needed? No
Required README updates made? No

This is a tentative PR primarily to open up discussion.  Questions:
* Currently we have 2 tearDownClass methods.  How does this manifest?
* Is it better to separate associated tests into their own classes.  Currently we only have 2 tests, however the user created in the second test has no relevance to the other tests.
* My opinion is that clean up of the DSConfig class should be handled by that class rather than the calling class.  I have found some potential solutions here https://stackoverflow.com/questions/865115/how-do-i-correctly-clean-up-a-python-object and have tried to implement the Python's "with" statement.  However, I seek advice from more experienced Python programmers.