### PR TITLE
Removes hard-coded platform secrets entry in favor of dynamic option

### DIFF
--- a/helm/frconfig/templates/secret-platform.yaml
+++ b/helm/frconfig/templates/secret-platform.yaml
@@ -6,9 +6,10 @@ metadata:
     name: {{ .Values.config.name }}-platform
 type: Opaque
 data:
-{{ if .Values.platform.idmProtectedByIg }}
-  IG_CLIENT_USERNAME: {{ default "openig" .Values.platform.igClientUsername | b64enc }}
-  IG_CLIENT_PASSWORD: {{ default "openig" .Values.platform.igClientPassword | b64enc }}
+{{ if .Values.secret.env }}
+{{- range $key, $value := .Values.secret.env }}
+   {{ $key }}: {{ $value | b64enc | quote }}
+{{- end }}
 {{ else }}
   {}
 {{ end }}

--- a/helm/frconfig/values.yaml
+++ b/helm/frconfig/values.yaml
@@ -11,15 +11,14 @@ config:
   # See README.md for more information.
   name: frconfig
 
+secret:
+  env:
+    {}
+
 git:
   # git repo to clone. The value below is a public git repo that does not require authentication.
   repo: "https://github.com/ForgeRock/forgeops-init.git"
   branch: master
-
-platform:
-  idmProtectedByIg: false
-  #igClientUsername: openig
-  #igClientPassword: openig
 
 # Cert manager defaults
 certmanager:


### PR DESCRIPTION
The hard-coded IG_CLIENT_USERNAME and IG_CLIENT_PASSWORD entries are now going to be specified as part of the helm values. In addition to removing this project-specific config from the general-purpose charts, it also allows other secrets to be specified as needed (for example, if someone wants to add a new secret that wasn't predicted, they can do so and it will become available as part of the environment for the various frconfig-dependent pods)