### PR TITLE
Adds end-user-ui docker image and helm chart

### DIFF
--- a/docker/end-user-ui/Dockerfile
+++ b/docker/end-user-ui/Dockerfile
@@ -1,0 +1,18 @@
+FROM alpine:3.8
+
+RUN apk add nodejs-current npm python2 build-base git
+RUN npm install -g http-server
+
+WORKDIR /tmp
+
+RUN git clone https://github.com/ForgeRock/end-user-ui.git
+
+WORKDIR /tmp/end-user-ui
+
+RUN git checkout 6.5.0 && npm install && npm run build
+
+WORKDIR /tmp/end-user-ui/dist
+
+EXPOSE 8888
+
+CMD ["http-server", "-p", "8888"]

--- a/helm/end-user-ui/.helmignore
+++ b/helm/end-user-ui/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/helm/end-user-ui/Chart.yaml
+++ b/helm/end-user-ui/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: Used to run the ForgeRock End User UI as a stand-alone service
+name: end-user-ui
+version: 0.1.0

--- a/helm/end-user-ui/templates/_helpers.tpl
+++ b/helm/end-user-ui/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+
+{{/* expands to the fqdn using the component name. Note domain has a leading . */}}
+{{- define "uiFQDN" -}}
+{{- if .Values.ingress.hostname  }}{{- printf "%s" .Values.ingress.hostname -}}
+{{- else -}}
+{{- printf "%s.%s%s" .Values.component .Release.Namespace .Values.domain -}}
+{{- end -}}
+{{- end -}}
+
+
+{{- define "end-user-ui.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "end-user-ui.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "end-user-ui.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/helm/end-user-ui/templates/deployment.yaml
+++ b/helm/end-user-ui/templates/deployment.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ include "end-user-ui.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "end-user-ui.name" . }}
+    helm.sh/chart: {{ include "end-user-ui.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "end-user-ui.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "end-user-ui.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8888
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+{{ toYaml .Values.resources | indent 12 }}

--- a/helm/end-user-ui/templates/ingress.yaml
+++ b/helm/end-user-ui/templates/ingress.yaml
@@ -1,0 +1,32 @@
+# Copyright (c) 2019 ForgeRock AS. Use of this source code is subject to the
+# Common Development and Distribution License (CDDL) that can be found in the LICENSE file
+# Ingress definition to configure external routes.
+{{- if .Values.ingress.enabled }}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ .Values.component }}
+  labels:
+    app: {{ template "fullname" . }}
+    vendor: forgerock
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+  annotations:
+    {{- range $key, $value := .Values.ingress.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  tls:
+  - hosts:
+    - {{ template "uiFQDN" .  }}
+    secretName: {{ printf "wildcard.%s%s" .Release.Namespace .Values.domain }}
+  rules:
+  - host: {{ template "uiFQDN" . }}
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: {{ include "end-user-ui.fullname" . }}
+          servicePort: {{ .Values.service.externalPort }}
+{{- end }}

--- a/helm/end-user-ui/templates/service.yaml
+++ b/helm/end-user-ui/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "end-user-ui.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "end-user-ui.name" . }}
+    helm.sh/chart: {{ include "end-user-ui.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.externalPort }}
+      targetPort: {{ .Values.service.internalPort }}
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ include "end-user-ui.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/helm/end-user-ui/values.yaml
+++ b/helm/end-user-ui/values.yaml
@@ -1,0 +1,27 @@
+# Default values for end-user-ui.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+# Top level domain. Used to create the ingress
+domain: .example.com
+
+# These are both used to form the FQDN for the load balancer.  See _helpers.tpl
+component: end-user-ui
+
+image:
+  repository: forgerock-docker-public.bintray.io/forgerock/end-user-ui
+  tag: 6.5.0
+  pullPolicy: IfNotPresent
+
+service:
+  name: end-user-ui
+  type: ClusterIP
+  externalPort: 80
+  internalPort: 8888
+
+
+ingress:
+  enabled: true
+  annotations: {}


### PR DESCRIPTION
This docker container will checkout the forgerock 6.5.0 end-user-ui from github and build it, ultimately running it as a stand-alone process. The associated helm chart will make it available within the kubernetes cluster via a new ingress.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/forgerock/forgeops/521)
<!-- Reviewable:end -->
