### PR TITLE
(CLOUD-1018) Change url to access userstore from inside the cluster

### DIFF
--- a/cicd/forgeops-tests/config/ProductConfig.py
+++ b/cicd/forgeops-tests/config/ProductConfig.py
@@ -93,8 +93,8 @@ class DSConfig(object):
     def __init__(self):
         self.reserved_ports = []
         if is_cluster_mode():
-            self.ds0_url = 'http://userstore-0.userstore:8080'
-            self.ds1_url = 'http://userstore-1.userstore:8080'
+            self.ds0_url = 'http://userstore-0.userstore.%s.svc.cluster.local:8080' % tests_namespace()
+            self.ds1_url = 'http://userstore-1.userstore.%s.svc.cluster.local:8080' % tests_namespace()
         else:
             self.helm_cmd = 'kubectl'
             (self.ds0_url, self.ds0_popen) = self.start_ds_port_forward(instance_nb=0)


### PR DESCRIPTION
Jira issue? CLOUD-1018
Release 6.5.0 backport required? no
6.5.0 doc changes needed? no
7.0.0 doc changes needed? no
Required README updates made? no

Now use `http://userstore-0.userstore.<namespace>.svc.cluster.local:8080` url to access the userstore from inside the cluster.
Previous urls were not valid if the toolbox and the deployment were not in the same namespace.