### PR TITLE
updated config path

### DIFF
--- a/samples/config/prod/l-cluster/openig.yaml
+++ b/samples/config/prod/l-cluster/openig.yaml
@@ -5,7 +5,7 @@ image:
 
 config:
   name: frconfig
-  path: /git/config/6.5/default/ig/basic-sample 
+  path: /git/config/6.5/cdm/m-cluster/ig 
   strategy: git
   
 resources:


### PR DESCRIPTION
updating incorrect path. ig lcluster path was set to default not cdm.

Jira issue? n/a
Release 6.5.0 backport required? no
6.5.0 doc changes needed? no
7.0.0 doc changes needed? no
Required README updates made? no
