### PR TITLE
include 'initContainers' iff there are init containers specified

### DIFF
--- a/helm/ds/templates/ds.yaml
+++ b/helm/ds/templates/ds.yaml
@@ -66,8 +66,8 @@ spec:
       # This will make sure the mounted PVCs are writable by the forgerock user with gid 111111.
       securityContext:
 {{ toYaml .Values.securityContext | indent 8 }}
-      initContainers:
       {{ if .Values.restore.enabled }}
+      initContainers:
       - name: restore
         image:  {{ .Values.image.repository }}:{{ .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}


### PR DESCRIPTION
This change moves the `initContainers` list entirely inside the `if .Values.restore.enabled` conditional statement, preventing yaml containing only `initContainers:` with no contents from being generated. While such yaml is accepted by `kubectl`, it is not correctly parsed by `kustomize` causing errors.

Some workflows (such as with Replicated Ship) use kustomize to additionally patch yaml generated by helm charts, and are thus impacted by this. See https://github.com/replicatedhq/ship/issues/800.