### PR TITLE
fix cert-manager version to 0.5.0

### DIFF
--- a/bin/deploy-cert-manager.sh
+++ b/bin/deploy-cert-manager.sh
@@ -33,7 +33,7 @@ do
 done
 
 # Deploy Cert Manager Helm chart
-helm upgrade -i cert-manager --namespace kube-system stable/cert-manager
+helm upgrade -i cert-manager --namespace kube-system stable/cert-manager --version v0.5.0
 
 # Check that cert-manager is up before deploying the cluster-issuer
 while true;

--- a/bin/gke-create-cluster.sh
+++ b/bin/gke-create-cluster.sh
@@ -82,7 +82,7 @@ gcloud beta container clusters create $GKE_CLUSTER_NAME \
       --enable-cloud-logging \
       --enable-cloud-monitoring \
       --disk-type=pd-ssd ${GKE_EXTRA_ARGS} \
-      --update-addons=Istio=ENABLED --istio-config=auth=MTLS_PERMISSIVE
+      --addons=Istio --istio-config=auth=MTLS_PERMISSIVE
 
 
 #  --enable-stackdriver-kubernetes


### PR DESCRIPTION
Jira issue? CLOUD-1104
Release 6.5.0 backport required? yes
6.5.0 doc changes needed? yes
7.0.0 doc changes needed? yes
Required README updates made? no

There is a bug with the latest version of cert-manager and kubectl version 1.12 and under so have stuck with the current deployment method but added previous version.
Also fixed broken flag for istio addon in cluster create script.