### PR TITLE
istio phase 2 CLOUD-1069

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,9 @@ helm install openam
 minikube ip
 
 # You can put DNS entries in an entry in /etc/hosts. For example:
-# 192.168.99.100 login.default.example.com openidm.default.example.com openig.default.example.com
+# 192.168.99.100 default.iam.example.com
 
-open https://login.default.example.com
+open https://default.iam.example.com/am
 
 ```
 

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -112,8 +112,10 @@ chk_config()
     fi
     echo -e "=>\tComponents: \"${COMPONENTS[*]}\""
 
-    AM_URL="${URL_PREFIX:-login}.${NAMESPACE}.${DOMAIN}"
-    IDM_URL="${IDM_URL_PREFIX:-openidm}.${NAMESPACE}.${DOMAIN}"
+    SUBDOMAIN="iam"
+    BASE_FQDN="${NAMESPACE}.${SUBDOMAIN}.${DOMAIN}"
+    AM_URL="${BASE_FQDN}/am"
+    IDM_URL="${BASE_FQDN}/idm"
 }
 
 create_namespace()

--- a/bin/istio-install.sh
+++ b/bin/istio-install.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#  *Demo* script to install istio. Please review the instructions 
+# at https://istio.io/docs/setup/kubernetes/quick-start/ 
+#
+
+# Run this relative to current directory
+mkdir -p tmp
+
+cd tmp
+
+echo "Downloading istio"
+curl -L https://git.io/getLatestIstio | sh -
+
+echo "Installing istio"
+
+cd istio-*
+
+echo "Install CRDs"
+kubectl apply -f install/kubernetes/helm/istio/templates/crds.yaml
+
+sleep 10
+
+echo "Install istio CRD"
+kubectl apply -f install/kubernetes/istio-demo.yaml
+
+
+echo "Done. Istio files are in $PWD"

--- a/bin/minikube-up.sh
+++ b/bin/minikube-up.sh
@@ -6,12 +6,11 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 cd $DIR
 
 minikube stop 
-minikube start --memory 6000 --kubernetes-version v1.11.2
+minikube start --memory 8192 --kubernetes-version v1.13.2
 
 sleep 5
 echo "Installing helm"
-./helm-rbac-init.sh
-
+helm init
 helm repo update
 
 sleep 10
@@ -19,3 +18,5 @@ sleep 10
 # Minikube needs a simplified version of cert manager for issuing CA certs.
 echo "Installing cert manager"
 helm upgrade -i cert-manager --namespace kube-system stable/cert-manager
+
+# todo: Install istio

--- a/cicd/argo/amster.yaml
+++ b/cicd/argo/amster.yaml
@@ -1,1 +1,1 @@
-domain: .forgeops.com
+domain: forgeops.com

--- a/cicd/argo/deploy.sh
+++ b/cicd/argo/deploy.sh
@@ -36,7 +36,4 @@ for app in frconfig openam amster; do
         --values ../../cicd/argo/$app.yaml
 
     argocd app sync test-$app
-
 done
-
-

--- a/cicd/argo/frconfig.yaml
+++ b/cicd/argo/frconfig.yaml
@@ -1,6 +1,6 @@
 
 certmanager:
-  enabled: true
+  enabled: false
   # The default issuer is to use the CA certs ssuer. 
   # issuer: ca-issuer
   # And a local to namespace issuer
@@ -10,4 +10,4 @@ certmanager:
   issuer: letsencrypt-prod
   issuerKind: ClusterIssuer
 
-domain: .forgeops.com
+domain: forgeops.com

--- a/cicd/argo/openam.yaml
+++ b/cicd/argo/openam.yaml
@@ -1,2 +1,2 @@
 
-domain: .forgeops.com
+domain: forgeops.com

--- a/cicd/toolbox/values.yaml
+++ b/cicd/toolbox/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-domain: .forgeops.com
+domain: forgeops.com
 
 replicaCount: 1
 

--- a/docker/amster/amster-install.sh
+++ b/docker/amster/amster-install.sh
@@ -14,8 +14,8 @@ POST_INSTALL_SCRIPTS=${POST_INSTALL_SCRIPTS:-"${AMSTER_SCRIPTS}"}
 
 
 # Use 'openam' as the internal cluster dns name.
-export SERVER_URL=${OPENAM_INSTANCE:-http://openam:80}
-export URI=${SERVER_URI:-/}
+export SERVER_URL=${OPENAM_INSTANCE:-http://openam:80/}
+export URI=${SERVER_URI:-/am}
 
 export INSTANCE="${SERVER_URL}${URI}"
 

--- a/docker/apache-agent/Dockerfile
+++ b/docker/apache-agent/Dockerfile
@@ -15,8 +15,8 @@ ENV AM_MAX_SHARED_POOL_SIZE 1048576000
 ENV AM_DEFAULT_LOG_LEVEL All
 
 # For testing purposes, you can build this image with ARGs to match your deployment
-ARG AM_SERVER=http://login.example.forgeops.com:80/
-ARG AGENT_SERVER=http://apache-agent.example.forgeops.com
+ARG AM_SERVER=http://default.iam.forgeops.com:80/am
+ARG AGENT_SERVER=http://default.iam.forgeops.com/apache-agent
 
 # Install needed sw
 RUN apt-get update && apt-get install --no-install-recommends  -y unzip curl vim && \

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -17,7 +17,7 @@ REGISTRY="forgerock-docker-public.bintray.io"
 
 REPO="forgerock"
 # Default tag if none is specified.
-TAG=${TAG:-6.5.0}
+TAG=${TAG:-7.0.0}
 
 # If you want to push to Google gcr.io, replace the repository name with your project name.
 PROJECT="engineering-devops"

--- a/docker/nginx-agent/Dockerfile
+++ b/docker/nginx-agent/Dockerfile
@@ -11,9 +11,8 @@ FROM nginx:1.11.10
 COPY --from=0 /var/tmp/web_agents /opt/web_agents
 
 WORKDIR /opt
-
-ARG AM_SERVER=http://login.example.forgeops.com:80/openam
-ARG AGENT_SERVER=http://apache-agent.example.forgeops.com
+ARG AM_SERVER=http://default.iam.forgeops.com:80/am
+ARG AGENT_SERVER=http://default.iam.forgeops.com/nginx-agent
 
 # Copy nginx.conf with included agent module
 COPY nginx.conf /etc/nginx/

--- a/docker/openam/Dockerfile
+++ b/docker/openam/Dockerfile
@@ -12,7 +12,7 @@ FROM tomcat:8.5-alpine
 
 RUN rm -fr "$CATALINA_HOME"/webapps/*
 
-COPY --from=0 /var/tmp/openam "$CATALINA_HOME"/webapps/ROOT
+COPY --from=0 /var/tmp/openam "$CATALINA_HOME"/webapps/am
 
 #ENV CATALINA_OPTS -server -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap
 # Option for setting the AM home directory:
@@ -47,7 +47,7 @@ RUN apk add --no-cache su-exec unzip curl bash tini \
   && adduser -s /bin/bash -h "$FORGEROCK_HOME" -u 11111 -D forgerock -G root \
   && mkdir -p "$OPENAM_HOME" \
   && mkdir -p "$FORGEROCK_HOME"/.openamcfg \
-  && echo "$OPENAM_HOME" >  "$FORGEROCK_HOME"/.openamcfg/AMConfig_usr_local_tomcat_webapps_ROOT_  \
+  && echo "$OPENAM_HOME" >  "$FORGEROCK_HOME"/.openamcfg/AMConfig_usr_local_tomcat_webapps_am_  \
   && chown -R forgerock:root "$CATALINA_HOME" \
   && chown -R forgerock:root  "$FORGEROCK_HOME" \
   && chmod -R g+rwx "$CATALINA_HOME"

--- a/docker/util/Dockerfile
+++ b/docker/util/Dockerfile
@@ -9,8 +9,6 @@ FROM alpine:3.7
 #  -Dcom.iplanet.services.debug.level=error
 
 ENV FORGEROCK_HOME /home/forgerock
-ENV OPENAM_HOME /home/forgerock/openam
-
 
 ENV KUBE_LATEST_VERSION="v1.10.1"
 

--- a/docker/util/am_bootstrap.sh
+++ b/docker/util/am_bootstrap.sh
@@ -13,6 +13,9 @@ CONFIGURATION_LDAP="${CONFIGURATION_LDAP:-configstore-0.configstore:1389}"
 DIR_MANAGER_PW_FILE=${DIR_MANAGER_PW_FILE:-/var/run/secrets/configstore/dirmanager.pw}
 
 OPENAM_HOME=${OPENAM_HOME:-/home/forgerock/openam}
+# Context root
+OPENAM_CTX=am
+AM_CTX="${OPENAM_HOME}/${OPENAM_CTX}"
 
 # Test the configstore to see if it contains a configuration. Return 0 if configured.
 is_configured() {
@@ -29,16 +32,17 @@ is_configured() {
 # If you ever change the am context (not recommended), you need to copy these files to OPENAM_HOME/$context
 copy_secrets() {
     echo "Copying secrets"
-    mkdir -p "${OPENAM_HOME}/secrets"
-    cp  -L /var/run/secrets/openam/.keypass "${OPENAM_HOME}"
-    cp  -L /var/run/secrets/openam/.storepass "${OPENAM_HOME}"
-    cp  -L /var/run/secrets/openam/keystore.jceks "${OPENAM_HOME}"
-    cp  -L /var/run/secrets/openam/keystore.jks "${OPENAM_HOME}"
+    mkdir -p "${AM_CTX}"
+    cp  -L /var/run/secrets/openam/.keypass "${AM_CTX}"
+    cp  -L /var/run/secrets/openam/.storepass "${AM_CTX}"
+    cp  -L /var/run/secrets/openam/keystore.jceks "${AM_CTX}"
+    cp  -L /var/run/secrets/openam/keystore.jks "${AM_CTX}"
     cp  -L /var/run/secrets/openam/authorized_keys "$OPENAM_HOME"
-    cp  -L /var/run/secrets/openam/openam_mon_auth "${OPENAM_HOME}"
+    cp  -L /var/run/secrets/openam/openam_mon_auth "${AM_CTX}"
     # The new AM secrets API specifies a directory for password secrets. Each file is a key, and the contents are the secret value
     # You can NOT use a leading dot 
     # In your global -> Secret Stores -> default-password-store - configure /home/forgerock/openam/secrets as your Directory
+    mkdir -p "${OPENAM_HOME}/secrets"
     cp -L /var/run/secrets/openam/.keypass "${OPENAM_HOME}/secrets/entrypass"
     cp -L /var/run/secrets/openam/.storepass "${OPENAM_HOME}/secrets/storepass"
 }
@@ -46,8 +50,7 @@ copy_secrets() {
 bootstrap() {
     if is_configured;
     then
-        echo "Configstore is present. Creating bootstrap"
-        mkdir -p "${OPENAM_HOME}/openam"
+        echo "Configstore is present. Copying bootstrap"
         cp -L /var/run/openam/*.json "$OPENAM_HOME"
     fi
 }

--- a/etc/istio/cluster-cert.yaml
+++ b/etc/istio/cluster-cert.yaml
@@ -1,5 +1,5 @@
 
-# Creates an SSL certifate request for the istio gateway.
+# Creates an SSL certifcate request for the istio gateway.
 # This should be installed for once per istio gateway - generally once per cluster
 # install using:
 # kubectl apply -f cluster-cert.yaml

--- a/helm/README.md
+++ b/helm/README.md
@@ -74,13 +74,14 @@ By default charts  deploy to the `default` namespace in Kubernetes.
 You can deploy multiple product instances in different namespaces and they will not 
 interfere with each other. For example, you might have 'dev', 'qa', and 'prod' namespaces. 
 
-To provide external ingress routes that are unique, the namespace can be used when forming the 
-ingress host name. The format is:
- {openam,openidm,openig}.{namespace}.{domain} 
+The default format used for the FQDN is:
+{namespace}.{subdomain}.{domain}/{am|idm|ig|openidm}
+
+subdomain defaults to "iam"
 
  For example:
 
- `login.default.example.com`
+ `default.iam.example.com`
 
 Note that the details of the ingress will depend on the implementation. You may need to modify the ingress definitions. 
  
@@ -88,26 +89,12 @@ Note that the details of the ingress will depend on the implementation. You may 
 
 All charts default to using TLS (https) for the inbound ingress.  
 
-Within a namespace, it is assumed that a single wildcard certificate secret is present `wildcard.$namespace.$domain`. This
-secret is referenced by each ingress controller in the `tls` spec.
+If you use nginx on minikube, the ingress will default to using the nginx self signed certificate. If you want to use nginx and a "real" SSL certificate you must modify the ingress.yaml in each chart, and provide a TLS secret.
 
-You can create the wildcard secret manually, but in these examples we assume
-that [cert-manager](https://github.com/jetstack/cert-manager) is installed and is provisioning certificates for you.
+For istio,  we assume  a wildcard certificate is obtained for the istio ingress for the entire cluster. 
+This certificate handles SSL for all namespaces: *.$subdomain.$domain. 
 
-
-The frconfig chart defaults to creating a cert-manager "CA" issuer. This is a simple issuer that issues certificates signed by a CA certificate installed as part of the frconfig chart. We have included a default CA certificate in frconfig/secrets. You can replace this with your own using the sample script `frconfig/secrets/cm.sh`, or replace it with an intermediate signing certificate issued by your organization.
-
-If you are on minikube, cert-manager can be installed using:
-
-`helm upgrade -i cert-manager --namespace kube-system stable/cert-manager`
-
-If you deploy the frconfig chart as-is: `helm install frconfig`  things should "just work". You will get a
-self signed certificate presented to the browser. You must accept the browser warnings, or import the CA cert found in frconfig/secrets into your browser's trusted certificate list.
-
-Alternatively, you can configure frconfig to create a cert-manager issuer for Let's Encrypt. Refer to the cert-manager docs for further details.
-
-If you do not see a secret `wildcard.$namespace.$domain`, it means that something has gone wrong with cert manager. Look in the cert-manager logs to find the cause. If you are using the Let's Encrypt issuer, keep in mind that it can take up to 10 minutes to provision a certificate.
-
+Note: The frconfig chart no longer defaults to enabling cert-manager - as it is not required by default.
 
 For further information on the above options, see the [DevOps developers guide](https://ea.forgerock.com/docs/platform/devops-guide/index.html#devops-implementation-env-https-access-secret).
 

--- a/helm/amster/templates/config-map.yaml
+++ b/helm/amster/templates/config-map.yaml
@@ -5,7 +5,7 @@ metadata:
 data:
   00_install.amster: |
     install-openam \
-    --serverUrl http://openam:80/ \
+    --serverUrl http://openam:80/am \
     --authorizedKey  /var/run/secrets/amster/authorized_keys \
     --cookieDomain {{.Values.domain }} \
     --adminPwd {{ .Values.amadminPassword }} \
@@ -26,7 +26,7 @@ data:
     --pwdEncKey {{ .Values.encryptionKey }} \
     --acceptLicense \
     --lbSiteName site1 \
-    --lbPrimaryUrl https://{{ template "fqdn" . }}/ \
+    --lbPrimaryUrl https://{{ .Release.Namespace }}.{{ .Values.istio.subdomain }}.{{ .Values.domain }}/am \
     --cfgDir /home/forgerock/openam
     :exit
   01_import.amster: |

--- a/helm/amster/values.yaml
+++ b/helm/amster/values.yaml
@@ -85,7 +85,7 @@ resources:
 # Optional value overrides
 
 # fqdn - the openam server external fqdn.
-# If this is *not* set, it defaults to login.{namespace}{{ .Values.domain }}
+# If this is *not* set, it defaults to {namespace}{subdomain}{domain}
 #fqdn: login.acme.com
 
 # ctsStores - is a csv separated list of avaiable cts servers. This is referenced in the amster configuration as &{ctsStores} on

--- a/helm/amster/values.yaml
+++ b/helm/amster/values.yaml
@@ -9,8 +9,8 @@ component: amster
 serverBase: http://openam:80
 
 
-# The top level domain (including the leading .). This excludes the openam component.
-domain: .example.com
+# The top level domain. This excludes the openam component.
+domain: example.com
 
 # Default install passwords.
 amadminPassword: password
@@ -35,7 +35,7 @@ config:
 
 image:
   repository: forgerock-docker-public.bintray.io/forgerock/amster
-  tag: 6.5.0
+  tag: 7.0.0
   pullPolicy: IfNotPresent
   #pullPolicy: Always
 
@@ -94,3 +94,9 @@ resources:
 
 # ctsPassword - defaults to "password"
 #ctsPassword: password
+
+
+istio:
+  enabled: false
+  subdomain: iam
+  

--- a/helm/apache-agent/values.yaml
+++ b/helm/apache-agent/values.yaml
@@ -5,7 +5,7 @@ replicaCount: 1
 
 component: apache-agent
 
-domain: .example.com
+domain: example.com
 image:
   repository: forgerock-docker-public.bintray.io/forgerock/apache-agent
   tag: latest

--- a/helm/ds/templates/ds.yaml
+++ b/helm/ds/templates/ds.yaml
@@ -32,6 +32,8 @@ spec:
   {{- end }}
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         instance: {{ .Values.instance }}
         app: {{ template "fullname" . }}

--- a/helm/end-user-ui/values.yaml
+++ b/helm/end-user-ui/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 
 # Top level domain. Used to create the ingress
-domain: .example.com
+domain: example.com
 
 # These are both used to form the FQDN for the load balancer.  See _helpers.tpl
 component: end-user-ui

--- a/helm/forgerock-metrics/values.yaml
+++ b/helm/forgerock-metrics/values.yaml
@@ -16,7 +16,7 @@ namespaceSelectorStrategy: any
 am:
   component: am
   enabled: true
-  path: /json/metrics/prometheus
+  path: /am/json/metrics/prometheus
   labelSelectorComponent: openam
   secretUser: prometheus
   secretPassword: prometheus

--- a/helm/frconfig/templates/cert-manager.yaml
+++ b/helm/frconfig/templates/cert-manager.yaml
@@ -27,7 +27,7 @@ kind: Certificate
 metadata:
   name:  wildcard.{{ .Release.Namespace }}{{ .Values.domain }}
 spec:
-  secretName: {{ printf "wildcard.%s%s" .Release.Namespace .Values.domain }}
+  secretName: {{ printf "wildcard.%s.%s" .Release.Namespace .Values.domain }}
   issuerRef:
     name: {{ .Values.certmanager.issuer }}
     kind: {{ default "Issuer" .Values.certmanager.issuerKind }}

--- a/helm/frconfig/templates/gateway.yaml
+++ b/helm/frconfig/templates/gateway.yaml
@@ -15,7 +15,7 @@ spec:
       name: http
       protocol: HTTP
     hosts:
-    - {{ .Release.Namespace}}.iam{{.Values.domain}}
+    - "{{ .Release.Namespace}}.{{ .Values.istio.subdomain }}.{{.Values.domain}}"
     tls:
       httpsRedirect: true
   - port:
@@ -23,7 +23,7 @@ spec:
       name: https
       protocol: HTTPS
     hosts:
-    - {{ .Release.Namespace}}.iam{{.Values.domain}}
+    - "{{ .Release.Namespace}}.{{ .Values.istio.subdomain }}.{{.Values.domain}}"
     tls:
       mode: SIMPLE
       privateKey: /etc/istio/ingressgateway-certs/tls.key

--- a/helm/frconfig/values.yaml
+++ b/helm/frconfig/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 
 # Top level domain, including the leading dot. This is used to form the wild-card cert request for cert-manager.
-domain: .example.com
+domain: example.com
 
 config:
   # The default name that products use when looking for the configmap and secret is `frconfig`.
@@ -22,7 +22,7 @@ git:
 
 # Cert manager defaults
 certmanager:
-  enabled: true
+  enabled: false
   # The default issuer is to use the CA certs issuer.
   issuer: ca-issuer
   # And a local to namespace issuer
@@ -34,3 +34,4 @@ certmanager:
 
 istio:
   enabled: false
+  subdomain: iam

--- a/helm/gatling-benchmark/values.yaml
+++ b/helm/gatling-benchmark/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 
 # Domain on which reports will be available
-domain: .forgeops.com
+domain: forgeops.com
 
 # Gatling image with tests.
 # Dockerfile for this image can be found in forgeops/docker/gatling

--- a/helm/nginx-agent/values.yaml
+++ b/helm/nginx-agent/values.yaml
@@ -17,7 +17,7 @@ resources:
     memory: 256Mi
 
 # Default cookie domain. Include the leading dot.
-domain: .example.com
+domain: example.com
 
 agent:
   user: nginx

--- a/helm/openam/templates/_helpers.tpl
+++ b/helm/openam/templates/_helpers.tpl
@@ -20,7 +20,7 @@ We truncate at 24 chars because some Kubernetes name fields are limited to this
 
 {{/* expands to the fqdn using the component name. Note domain has a leading . */}}
 {{- define "externalFQDN2" -}}
-{{- printf "login.%s%s"  .Release.Namespace .Values.domain -}}
+{{- printf "login.%s.%s"  .Release.Namespace .Values.domain -}}
 {{- end -}}
 
 
@@ -29,7 +29,7 @@ We truncate at 24 chars because some Kubernetes name fields are limited to this
 {{- define "externalFQDN" -}}
 {{- if .Values.ingress.hostname  }}{{- printf "%s" .Values.ingress.hostname -}}
 {{- else -}}
-{{- printf "login.%s%s" .Release.Namespace .Values.domain -}}
+{{- printf "login.%s.%s" .Release.Namespace .Values.domain -}}
 {{- end -}}
 {{- end -}}
 

--- a/helm/openam/templates/config-map.yaml
+++ b/helm/openam/templates/config-map.yaml
@@ -10,14 +10,14 @@ metadata:
 data:
   boot.json: |
    {
-     "instance" : "{{ default "http://openam:80" .Values.openamInstance }}",
+     "instance" : "{{ .Values.am.instance }}",
      "dsameUser" : "cn=dsameuser,ou=DSAME Users,{{ .Values.rootSuffix }}",
      "keystores" : {
        "default" : {
-         "keyStorePasswordFile" : "/home/forgerock/openam/.storepass",
-         "keyPasswordFile" : "/home/forgerock/openam/.keypass",
+         "keyStorePasswordFile" : "{{ .Values.am.bootstrapDir }}/.storepass",
+         "keyPasswordFile" : "{{ .Values.am.bootstrapDir }}/.keypass",
          "keyStoreType" : "JCEKS",
-         "keyStoreFile" : "/home/forgerock/openam/keystore.jceks"
+         "keyStoreFile" : "{{ .Values.am.bootstrapDir }}/keystore.jceks"
        }
      },
      "configStoreList" : [ {

--- a/helm/openam/templates/ingress.yaml
+++ b/helm/openam/templates/ingress.yaml
@@ -19,19 +19,15 @@ metadata:
 spec:
   tls:
   - hosts:
-    - {{ template "externalFQDN" .  }}
-    secretName: {{ printf "wildcard.%s%s" .Release.Namespace .Values.domain }}
+    - "{{ .Release.Namespace }}.{{.Values.subdomain }}.{{ .Values.domain }}"
+  # We default to using the nginx self signed cert.
+  #   secretName: {{ printf "wildcard.%s.%s" .Release.Namespace .Values.domain }}
   rules:
-    - host: {{ template "externalFQDN" . }}
+    - host: "{{ .Release.Namespace }}.{{.Values.subdomain }}.{{ .Values.domain }}"
       http:
         paths:
-        - path: /
+        - path: /am
           backend:
             serviceName: {{ .Values.service.name }}
             servicePort: {{ .Values.service.externalPort }}
-        - path: /openam
-          backend:
-            serviceName: {{ .Values.service.name }}
-            servicePort: {{ .Values.service.externalPort }}
-
 {{- end -}}

--- a/helm/openam/templates/istio.yaml
+++ b/helm/openam/templates/istio.yaml
@@ -1,0 +1,34 @@
+{{ if .Values.istio.enabled }}
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: "{{ .Values.component }}"
+spec:
+  hosts:
+  - "{{ .Release.Namespace }}.{{.Values.subdomain }}.{{ .Values.domain }}"
+  gateways: [ "iam-gateway" ]
+  http: [{ 
+    match: [ 
+      { uri: { prefix: "/am" }}
+    ],
+    route: [{
+      destination: { 
+        host: "{{ .Values.service.name }}", 
+        port: { number: {{ .Values.service.externalPort }} }
+      } 
+    }]
+  }]
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: "{{ .Values.component }}"
+spec:
+  host:  "{{ .Values.service.name }}"
+  trafficPolicy:
+     loadBalancer:
+       consistentHash:
+         httpCookie:
+           name: iPlanetDirectoryPro
+           ttl: 0s
+{{ end }}

--- a/helm/openam/templates/openam-deployment.yaml
+++ b/helm/openam/templates/openam-deployment.yaml
@@ -93,14 +93,14 @@ spec:
         # For slow environments like Minikube you need to give OpenAM time to come up.
         readinessProbe:
           httpGet:
-            path: /isAlive.jsp
+            path: /am/isAlive.jsp
             port: 8080
           initialDelaySeconds: 30
           timeoutSeconds: 5
           periodSeconds: 20
         livenessProbe:
           httpGet:
-            path: /isAlive.jsp
+            path: /am/isAlive.jsp
             port: 8080
           initialDelaySeconds: 30
           timeoutSeconds: {{ .Values.livenessTimeout }}

--- a/helm/openam/values.yaml
+++ b/helm/openam/values.yaml
@@ -6,7 +6,7 @@ component: openam
 
 image:
   repository: forgerock-docker-public.bintray.io/forgerock/openam
-  tag: 6.5.0
+  tag: 7.0.0
   # For development we set this to Always to get the most current image:
   pullPolicy: IfNotPresent
 
@@ -17,10 +17,12 @@ gitImage:
 
 utilImage:
   repository: forgerock-docker-public.bintray.io/forgerock/util
-  tag: 6.5.0
+  tag: 7.0.0
   pullPolicy: IfNotPresent
+  #pullPolicy: Always
 
-domain: .example.com
+domain: example.com
+subdomain: iam
 
 config:
   name: frconfig
@@ -28,7 +30,6 @@ config:
 
 openamReplicaCount: 1
 
-openamInstance: http://openam:80
 
 configLdapPort:  1389
 configLdapHost: configstore-0.configstore
@@ -59,6 +60,14 @@ useConfigMapWebxml: false
 
 # Suffix for DS config store.
 rootSuffix:  "ou=am-config"
+
+am:
+  home: /home/forgerock/openam
+  context: am
+  bootstrapDir: /home/forgerock/openam/am
+  instance: http://openam:80/am
+
+
 
 # Valid logger types: fluent-bit, none
 # For audit logs it is suggested you configure AM to send directly to ElasticSearch.
@@ -95,17 +104,14 @@ ingress:
   enabled: true
   annotations:
     kubernetes.io/ingress.class: nginx
-    nginx.ingress.kubernetes.io/cors-allow-origin: "*"
     nginx.ingress.kubernetes.io/affinity: "cookie"
     nginx.ingress.kubernetes.io/session-cookie-name: "route"
     nginx.ingress.kubernetes.io/session-cookie-hash: "sha1"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
-    nginx.ingress.kubernetes.io/enable-cors: "true"
-    nginx.ingress.kubernetes.io/cors-allow-methods: "PUT,GET,POST,HEAD,PATCH,DELETE"
-    nginx.ingress.kubernetes.io/cors-allow-headers: "authorization,x-requested-with"
-    nginx.ingress.kubernetes.io/cors-allow-credentials: "false"
-    nginx.ingress.kubernetes.io/cors-max-age: "600"
-    nginx.ingress.kubernetes.io/rewrite-target: "/"
+    # nginx.ingress.kubernetes.io/enable-cors: "true"
+    # nginx.ingress.kubernetes.io/cors-allow-methods: "PUT,GET,POST,HEAD,PATCH,DELETE"
+    # nginx.ingress.kubernetes.io/cors-allow-headers: "authorization,x-requested-with"
+    # nginx.ingress.kubernetes.io/cors-allow-credentials: "false"
 
 # Audit log details for log streaming sidecar containers.
 # AM can now stream audit logs to stdout. This option may be removed in the future.
@@ -120,3 +126,8 @@ auditLogs: []
 #     path: "/home/forgerock/openam/openam/log/authentication.audit.json"
 #   - name: config-logs
 #     path: "/home/forgerock/openam/openam/log/config.audit.json"
+
+
+istio:
+  enabled: false
+

--- a/helm/openidm/templates/NOTES.txt
+++ b/helm/openidm/templates/NOTES.txt
@@ -1,3 +1,4 @@
-OpenIDM should be available soon at the ingress address of http://{{ template "idmFQDN" . }}
+OpenIDM should be available soon at the ingress address of https://{{ .Release.Namespace }}.{{.Values.subdomain }}.{{ .Values.domain }}/admin
+
 
 It can take a few minutes for the ingress to become ready.

--- a/helm/openidm/templates/configmap.yaml
+++ b/helm/openidm/templates/configmap.yaml
@@ -43,7 +43,7 @@ data:
       openidm.port.http=8080
       openidm.port.https=8443
       openidm.port.mutualauth=8444
-      openidm.host={{ template "idmFQDN" . }}
+      openidm.host={{ printf "%s.%s.%s" .Release.Namespace .Values.istio.subdomain .Values.domain }}
 
       # Define external load balancer ports.
       openidm.lb.port.http=80

--- a/helm/openidm/templates/ingress.yaml
+++ b/helm/openidm/templates/ingress.yaml
@@ -19,14 +19,31 @@ metadata:
 spec:
   tls:
   - hosts:
-    - {{ template "idmFQDN" .  }}
-    secretName: {{ printf "wildcard.%s%s" .Release.Namespace .Values.domain }}
+    - "{{ .Release.Namespace }}.{{.Values.subdomain }}.{{ .Values.domain }}"
+  # We default to using the nginx self signed cert.
+  #   secretName: {{ printf "wildcard.%s.%s" .Release.Namespace .Values.domain }}
   rules:
-  - host: {{ template "idmFQDN" . }}
-    http:
-      paths:
-      - path: /
-        backend:
-          serviceName: {{ .Values.service.name }}
-          servicePort: {{ .Values.service.externalPort }}   
+    - host: "{{ .Release.Namespace }}.{{.Values.subdomain }}.{{ .Values.domain }}"
+      http:
+        paths:
+        - path: /idm
+          backend:
+            serviceName: {{ .Values.service.name }}
+            servicePort: {{ .Values.service.externalPort }}
+        - path: /api
+          backend:
+            serviceName: {{ .Values.service.name }}
+            servicePort: {{ .Values.service.externalPort }}
+        - path: /openidm
+          backend:
+            serviceName: {{ .Values.service.name }}
+            servicePort: {{ .Values.service.externalPort }}
+        - path: /oauthReturn
+          backend:
+            serviceName: {{ .Values.service.name }}
+            servicePort: {{ .Values.service.externalPort }}
+        - path: /admin
+          backend:
+            serviceName: {{ .Values.service.name }}
+            servicePort: {{ .Values.service.externalPort }}
 {{- end -}}

--- a/helm/openidm/templates/virtual-service.yaml
+++ b/helm/openidm/templates/virtual-service.yaml
@@ -1,0 +1,25 @@
+{{ if .Values.istio.enabled }}
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: "{{ .Values.component }}"
+spec:
+  hosts:
+  - "{{ .Release.Namespace }}.{{.Values.subdomain }}.{{ .Values.domain }}"
+  gateways: [ "iam-gateway" ]
+  http: [{ 
+    match: [ 
+      { uri: { prefix: "/idm" }},
+      { uri: { prefix: "/api" }},
+      { uri: { prefix: "/openidm" }},
+      { uri: { prefix: "/oauthReturn" }},
+      { uri: { prefix: "/admin" }}
+    ],
+    route: [{
+      destination: { 
+        host: "{{ .Values.service.name }}", 
+        port: { number: {{ .Values.service.externalPort }} }
+      } 
+    }]
+  }] 
+{{ end }}

--- a/helm/openidm/values.yaml
+++ b/helm/openidm/values.yaml
@@ -5,7 +5,8 @@
 replicaCount: 1
 
 # Top level domain. Used to create the ingress
-domain: .example.com
+domain: example.com
+subdomain: iam
 
 # Configuration parameters. Common to all charts that require configuration from a
 # source. Currently the only source is a git repo.
@@ -15,7 +16,7 @@ config:
   name: frconfig
   # Path to our project
   # path: /git/config/samples/idm/idm-am-ds-integration
-  path: /git/config/6.5/default/idm/sync-with-ldap-bidirectional
+  path: /git/config/7.0/default/idm/sync-with-ldap-bidirectional
   #
   # strategy defines how products get their configuration .
   # Using the git strategy, each helm chart pulls the configuration from git using an init container.
@@ -78,7 +79,8 @@ userstore:
 
 service:
   name: openidm
-  type: NodePort
+  # default to ClusterIP
+  #type: NodePort
   externalPort: 80
   internalPort: 8080
 
@@ -99,8 +101,14 @@ ingress:
   enabled: true
   annotations:
     # Nginx specific annotations
+    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/affinity: "cookie"
+    nginx.ingress.kubernetes.io/session-cookie-name: "route"
+    nginx.ingress.kubernetes.io/session-cookie-hash: "sha1"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
+
+istio:
+  enabled: false
 
 # Audit log details for log streaming sidecar containers
 # IDM can now stream logs to stdout. This setting will be deprecated in the future.

--- a/helm/openig/templates/NOTES.txt
+++ b/helm/openig/templates/NOTES.txt
@@ -16,4 +16,4 @@
 
 
 If you have an ingress controller, you can also access IG at
-http://{{ template "igFQDN" . }}
+https://"{{ .Release.Namespace }}.{{.Values.subdomain }}.{{ .Values.domain }}"/ig

--- a/helm/openig/templates/ingress.yaml
+++ b/helm/openig/templates/ingress.yaml
@@ -19,14 +19,15 @@ metadata:
 spec:
   tls:
   - hosts:
-    - {{ template "igFQDN" .  }}
-    secretName: {{ printf "wildcard.%s%s" .Release.Namespace .Values.domain }}
+    - "{{ .Release.Namespace }}.{{.Values.subdomain }}.{{ .Values.domain }}"
+  # We default to using the nginx self signed cert.
+  #   secretName: {{ printf "wildcard.%s.%s" .Release.Namespace .Values.domain }}
   rules:
-  - host: {{ template "igFQDN" . }}
-    http:
-      paths:
-      - path: /
-        backend:
-          serviceName: {{ .Values.service.name }}
-          servicePort: {{ .Values.service.externalPort }}  
+    - host: "{{ .Release.Namespace }}.{{.Values.subdomain }}.{{ .Values.domain }}"
+      http:
+        paths:
+        - path: /ig
+          backend:
+            serviceName: {{ .Values.service.name }}
+            servicePort: {{ .Values.service.externalPort }}
 {{- end -}}

--- a/helm/openig/values.yaml
+++ b/helm/openig/values.yaml
@@ -6,7 +6,8 @@
 # Declare variables to be passed into your templates.
 replicaCount: 1
 
-domain: .example.com
+domain: example.com
+subdomain: iam
 
 # Configuration parameters. Common to all charts that require configuration from a
 # source. Currently the only source is a git repo.
@@ -60,7 +61,6 @@ ingress:
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/affinity: "cookie"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
-    nginx.ingress.kubernetes.io/enable-cors: "false"
 
 # Audit log details for log streaming sidecar containers
 

--- a/helm/web/templates/NOTES.txt
+++ b/helm/web/templates/NOTES.txt
@@ -1,19 +1,3 @@
-1. Get the application URL by running these commands:
-{{- if .Values.ingress.enabled }}
-{{- range .Values.ingress.hosts }}
-  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ . }}{{ $.Values.ingress.path }}
-{{- end }}
-{{- else if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "web.fullname" . }})
-  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-  echo http://$NODE_IP:$NODE_PORT
-{{- else if contains "LoadBalancer" .Values.service.type }}
-     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get svc -w {{ template "web.fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "web.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-  echo http://$SERVICE_IP:{{ .Values.service.port }}
-{{- else if contains "ClusterIP" .Values.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "web.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-  echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl port-forward $POD_NAME 8080:80
-{{- end }}
+
+
+Open https://{{ .Release.Namespace }}.{{.Values.subdomain }}.{{ .Values.domain }}/web

--- a/helm/web/templates/configmap.yaml
+++ b/helm/web/templates/configmap.yaml
@@ -16,13 +16,13 @@ data:
       <h3>Links</h3>
       <ul>
         <li>
-          <a href="https://login.{{ .Release.Namespace }}{{ .Values.domain}}/openam" target="_blank">AM</a>
+          <a href="/am" target="_blank">AM</a>
         </li>
         <li>
-          <a href="https://openidm.{{ .Release.Namespace }}{{ .Values.domain}}" target="_blank">IDM</a>
+          <a href="/admin" target="_blank">IDM</a>
         </li>
         <li>
-          <a href="https://openig.{{ .Release.Namespace }}{{ .Values.domain}}" target="_blank">IG</a>
+          <a href="/ig" target="_blank">IG</a>
         </li>
       </ul>
     </html>

--- a/helm/web/templates/ingress.yaml
+++ b/helm/web/templates/ingress.yaml
@@ -18,17 +18,13 @@ metadata:
 spec:
   tls:
   - hosts:
-    - {{ printf "www.%s%s" .Release.Namespace .Values.domain }}
-  secretName: {{ printf "wildcard.%s%s" .Release.Namespace .Values.domain }}
+    - "{{ .Release.Namespace }}.{{.Values.subdomain }}.{{ .Values.domain }}"
+  #secretName: {{ printf "wildcard.%s%s" .Release.Namespace .Values.domain }}
   rules:
-  - host: {{ printf "www.%s%s" .Release.Namespace .Values.domain }}
+  - host: "{{ .Release.Namespace }}.{{.Values.subdomain }}.{{ .Values.domain }}"
     http:
       paths:
       - path: {{ .Values.ingress.path }}
-        backend:
-          serviceName: {{ template "web.fullname" . }}
-          servicePort: {{ .Values.service.port }}  
-      - path: {{ .Values.ingress.rewritePath }}
         backend:
           serviceName: {{ template "web.fullname" . }}
           servicePort: {{ .Values.service.port }}  

--- a/helm/web/values.yaml
+++ b/helm/web/values.yaml
@@ -4,7 +4,8 @@
 
 replicaCount: 1
 
-domain: .example.com
+domain: example.com
+subdomain: iam
 
 service:
   type: ClusterIP
@@ -16,7 +17,7 @@ ingress:
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/rewrite-target: "/"
-  path: /
+  path: /web
   #rewritePath: /path
   
 

--- a/samples/config/dev/benchmark-am/amster.yaml
+++ b/samples/config/dev/benchmark-am/amster.yaml
@@ -4,7 +4,6 @@ config:
   exportPath: /tmp/amster
 
 version: 6.0.0
-fqdn: login.pavel.forgeops.com
 # For production set CPU limits to help Kube Schedule the pods.
 resources:
  limits:

--- a/samples/config/dev/benchmark-am/common.yaml
+++ b/samples/config/dev/benchmark-am/common.yaml
@@ -1,4 +1,4 @@
-domain: .forgeops.com
+domain: forgeops.com
 
 image:
   tag: 6.5.0

--- a/samples/config/dev/benchmark-idm/common.yaml
+++ b/samples/config/dev/benchmark-idm/common.yaml
@@ -1,4 +1,4 @@
-domain: .forgeops.com
+domain: forgeops.com
 
 image:
   tag: 6.5.0

--- a/samples/config/dev/benchmark-ig/openig.yaml
+++ b/samples/config/dev/benchmark-ig/openig.yaml
@@ -7,7 +7,7 @@ image:
   pullPolicy: Always
   # The domain - including a leading dot '.'.  Product FQDNs are formed using this domain.
   # The format is  {component}.{kube-namespace}.{domain}.  For example: login.default.example.com
-domain: .forgeops.com
+domain: forgeops.com
 
 config:
   claim: frconfig

--- a/samples/config/dev/mini/common.yaml
+++ b/samples/config/dev/mini/common.yaml
@@ -1,10 +1,5 @@
-domain: .example.com
+domain: example.com
 
-fqdn: login.mini.example.com
-
-image:
-  tag: 6.5.0
-  pullPolicy: IfNotPresent
-
-tlsStrategy: http
+certmanager:
+  enabled: false
   

--- a/samples/config/dev/mini/userstore.yaml
+++ b/samples/config/dev/mini/userstore.yaml
@@ -1,0 +1,1 @@
+instance: userstore

--- a/samples/config/dev/multi-ds/common.yaml
+++ b/samples/config/dev/multi-ds/common.yaml
@@ -1,4 +1,4 @@
-domain: .forgeops.com
+domain: forgeops.com
 
 image:
   tag: 6.5.0

--- a/samples/config/prod/l-cluster/common.yaml
+++ b/samples/config/prod/l-cluster/common.yaml
@@ -2,8 +2,8 @@
 # by running generate-tls.sh script or you have to have cert-manager deployed
 # for your DNS domain
 
-domain: .frk8s.net
-#domain: .freng.org
+domain: frk8s.net
+#domain: freng.org
 
 fqdn: login.prod.frk8s.net
 

--- a/samples/config/prod/m-cluster/common.yaml
+++ b/samples/config/prod/m-cluster/common.yaml
@@ -5,9 +5,6 @@
 domain: frk8s.net
 #domain: freng.org
 
-fqdn: login.prod.frk8s.net
-#fqdn: login.medium.freng.org
-
 # Install passwords.
 amadminPassword: password
 encryptionKey: "123456789012"

--- a/samples/config/prod/m-cluster/common.yaml
+++ b/samples/config/prod/m-cluster/common.yaml
@@ -2,8 +2,8 @@
 # by running generate-tls.sh script or you have to have cert-manager deployed
 # for your DNS domain
 
-domain: .frk8s.net
-#domain: .freng.org
+domain: frk8s.net
+#domain: freng.org
 
 fqdn: login.prod.frk8s.net
 #fqdn: login.medium.freng.org

--- a/samples/config/prod/s-cluster/common.yaml
+++ b/samples/config/prod/s-cluster/common.yaml
@@ -2,8 +2,8 @@
 # by running generate-tls.sh script or you have to have cert-manager deployed
 # for your DNS domain 
 
-#domain: .freng.org
-domain: .frk8s.net
+#domain: freng.org
+domain: frk8s.net
 
 #fqdn: login.small.freng.org
 fqdn: login.prod.frk8s.net

--- a/samples/config/prod/s-cluster/common.yaml
+++ b/samples/config/prod/s-cluster/common.yaml
@@ -5,9 +5,6 @@
 #domain: freng.org
 domain: frk8s.net
 
-#fqdn: login.small.freng.org
-fqdn: login.prod.frk8s.net
-
 # Install passwords.
 amadminPassword: password
 encryptionKey: "123456789012"

--- a/samples/config/prometheus-values/l-cluster.yaml
+++ b/samples/config/prometheus-values/l-cluster.yaml
@@ -8,7 +8,7 @@ deployKubeScheduler: False
 # Controller Manager
 deployKubeControllerManager: False
 
-domain: .large.frk8s.net
+domain: large.frk8s.net
 
 grafana:
   storageSpec:

--- a/samples/config/prometheus-values/m-cluster.yaml
+++ b/samples/config/prometheus-values/m-cluster.yaml
@@ -8,7 +8,7 @@ deployKubeScheduler: False
 # Controller Manager
 deployKubeControllerManager: False
 
-domain: .perf.forgerock-qa.com
+domain: perf.forgerock-qa.com
 
 grafana:
   storageSpec:

--- a/samples/config/prometheus-values/shared-cluster.yaml
+++ b/samples/config/prometheus-values/shared-cluster.yaml
@@ -1,5 +1,5 @@
 # tls domain if ingress enabled
-domain: .forgeops.com
+domain: forgeops.com
 
 grafana:
   ingress:

--- a/samples/config/smoke-deployment/common.yaml
+++ b/samples/config/smoke-deployment/common.yaml
@@ -1,4 +1,4 @@
-domain: .forgeops.com
+domain: forgeops.com
 
 image:
   pullPolicy: Always

--- a/samples/config/smoke-deployment/frconfig.yaml
+++ b/samples/config/smoke-deployment/frconfig.yaml
@@ -3,4 +3,4 @@ git:
   branch: master
 
 
-domain: .forgeops.com
+domain: forgeops.com


### PR DESCRIPTION

This is a big update.  Please read:
 
https://docs.google.com/document/d/1s4UVJ2RcuRIO3GEXm9FQ5aESsJNrh2bWIT_rcsUBq3w 

* Updates for AM istio support. Moved am to /am context root
* Ad AM istio templates. Add istio install script to bin/
* Remove tlsSecret from all ingress to let it default to nginx
* Update idm/ig ingress to align with new fqdn

Fixed domain: setting to strip the leading dot.  Created mini dev sample config

Jira issue?  CLOUD-1069
Release 6.5.0 backport required? no
7.0.0 doc changes needed?  yes
Required README updates made? no
