### PR TITLE
Updates end-user-ui port to run on 8080 instead of 8888

### DIFF
--- a/docker/end-user-ui/Dockerfile
+++ b/docker/end-user-ui/Dockerfile
@@ -13,6 +13,6 @@ RUN git checkout 6.5.0 && npm install && npm run build
 
 WORKDIR /tmp/end-user-ui/dist
 
-EXPOSE 8888
+EXPOSE 8080
 
-CMD ["http-server", "-p", "8888"]
+CMD ["http-server", "-p", "8080"]

--- a/helm/end-user-ui/templates/deployment.yaml
+++ b/helm/end-user-ui/templates/deployment.yaml
@@ -25,7 +25,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: 8888
+              containerPort: {{ .Values.service.internalPort }}
               protocol: TCP
           livenessProbe:
             httpGet:

--- a/helm/end-user-ui/values.yaml
+++ b/helm/end-user-ui/values.yaml
@@ -19,7 +19,7 @@ service:
   name: end-user-ui
   type: ClusterIP
   externalPort: 80
-  internalPort: 8888
+  internalPort: 8080
 
 
 ingress:


### PR DESCRIPTION
Using 8888 was causing some annoying conflicts with skaffold and the example oauth2 clients. It's just easier to have the end-user-ui use 8080 like most of our other web apps.