### PR TITLE
CLOUD-1076 test am metadata

### DIFF
--- a/cicd/forgeops-tests/config/6.5.0-manifest.txt
+++ b/cicd/forgeops-tests/config/6.5.0-manifest.txt
@@ -1,0 +1,31 @@
+[DEFAULT]
+legal_notices = Forgerock_License.txt copyrights.txt third-party-copyrights.txt third-party-licenses
+    Apache-2.0.txt BSD-2-Clause.txt BSD-3-Clause.txt BSD.txt Bouncy_Castle_License.txt
+    CC0-1.0.txt CDDL-1.0.txt CDDL-1.1.txt CDDL_or_GPLv2_with_exceptions.txt CPL-1.0.txt
+    EPL-1.0.txt JSON.txt MIT.txt MPL-2.0.txt
+version = 6.5.0
+                 
+[openam]
+legal_notices = /usr/local/tomcat/webapps/am/legal-notices:
+    /usr/local/tomcat/webapps/am/legal-notices/third-party-licenses:
+    CDDL-1.0.txt
+version = 6.5.0
+revision = f8ac1261d9
+date = 2018-November-28 15:19
+jdk_version = openjdk version "1.8.0_191"
+jre_version = OpenJDK Runtime Environment (IcedTea 3.10.0) (Alpine 8.191.12-r0)
+jdk_full_version = OpenJDK 64-Bit Server VM (build 25.191-b12, mixed mode)
+commons_version = 24.0.1
+
+[amster]
+legal_notices = /opt/amster/legal-notices:
+    /opt/amster/legal-notices/third-party-licenses:
+version = 6.5.0
+revision = f8ac1261d9
+date = 2018-November-28 15:19
+jdk_version = openjdk version "1.8.0_151"
+jre_version = OpenJDK Runtime Environment (IcedTea 3.6.0) (Alpine 8.151.12-r0)
+jdk_full_version = OpenJDK 64-Bit Server VM (build 25.151-b12, mixed mode)
+commons_version = 24.0.1
+amster_jvm = 1.8.0_151
+    

--- a/cicd/forgeops-tests/install-deps.sh
+++ b/cicd/forgeops-tests/install-deps.sh
@@ -9,3 +9,5 @@ pip3 install allure-pytest
 pip3 install pytest-html
 pip3 install pytest-metadata
 pip3 install requests
+pip3 install multiset
+pip3 install kubernetes

--- a/cicd/forgeops-tests/lib/utils/am_pod.py
+++ b/cicd/forgeops-tests/lib/utils/am_pod.py
@@ -1,0 +1,100 @@
+# Copyright (c) 2016-2019 ForgeRock AS. Use of this source code is subject to the
+# Common Development and Distribution License (CDDL) that can be found in the LICENSE file
+
+"""
+Metadata related to kubernetes AM pods
+"""
+
+# Lib imports
+import os
+from requests import get, post
+
+# Framework imports
+from ProductConfig import AMConfig
+from utils import logger, rest, kubectl
+from utils.pod import Pod
+
+
+class AMPod(Pod):
+    PRODUCT_TYPE = 'openam'
+    ROOT = os.path.join(os.sep, 'usr', 'local', 'tomcat')
+    TEMP = os.path.join(ROOT, 'fr-tmp')
+
+    def __init__(self, name, manifest_filepath):
+        """
+        :param name: Pod name
+        :param manifest_filepath: Path to product manifest file
+        """
+
+        Pod.__init__(self, AMPod.PRODUCT_TYPE, name, manifest_filepath)
+
+    def is_expected_version(self):
+        """
+        Return True if the version is as expected, otherwise assert.
+        :return: True if the version is as expected.
+        """
+
+        amcfg = AMConfig()
+
+        logger.info('Get admin token')
+        headers = {'X-OpenAM-Username': 'amadmin', 'X-OpenAM-Password': 'password',
+                   'Content-Type': 'application/json', 'Accept-API-Version': 'resource=2.0, protocol=1.0'}
+
+        response = post(verify=amcfg.ssl_verify, url=amcfg.rest_authn_url, headers=headers)
+        rest.check_http_status(http_result=response, expected_status=200)
+        admin_token = response.json()['tokenId']
+
+        logger.info('Get AM version')
+        headers = {'Content-Type': 'application/json', 'Accept-API-Version': 'resource=1.0',
+                   'iplanetdirectorypro': admin_token}
+        response = get(verify=amcfg.ssl_verify, url=amcfg.am_url + '/json/serverinfo/version', headers=headers)
+        rest.check_http_status(http_result=response, expected_status=200)
+
+        logger.info('Check AM version')
+        assert response.json()['version'] == self.manifest['version'], 'Unexpected AM version'
+        assert response.json()['revision'] == self.manifest['revision'], 'Unexpected AM build revision'
+        assert response.json()['date'] == self.manifest['date'], 'Unexpected AM build date'
+        return True
+
+    def is_expected_legal_notices(self):
+        """
+        Return True if legal notices are as expected, otherwise assert.
+        :return: True if legal notices are as expected
+        """
+
+        super(AMPod, self).is_expected_legal_notices(os.path.join(AMPod.ROOT, 'webapps', 'am', 'legal-notices'))
+
+
+    def setup_commons_check(self):
+        """Setup for checking commons library version"""
+
+        logger.debug('Setting up for commons version check')
+        config_version_jar = 'config-%s.jar' % self.manifest['commons_version']
+        test_jar_filepath = os.path.join(AMPod.ROOT, 'webapps', 'am', 'WEB-INF', 'lib', config_version_jar)
+        return super(AMPod, self).setup_commons_check(test_jar_filepath, AMPod.TEMP)
+
+    def cleanup_commons_check(self):
+        """Cleanup after checking commons library version"""
+
+        logger.debug('Cleaning up after commons version check')
+        return super(AMPod, self).cleanup_commons_check(AMPod.TEMP)
+
+    def is_expected_commons_version(self):
+        """
+        Return true if the commons version is as expected, otherwise return assert.
+        This check inspects a sample commons .jar to see what version is in use.
+        :return: True is the commons version is as expected.
+        """
+
+        config_jar_properties = os.path.join('META-INF', 'maven', 'org.forgerock.commons', 'config', 'pom.properties')
+        logger.debug('Check commons version for config.jar')
+        return super(AMPod, self).is_expected_commons_version(AMPod.TEMP, config_jar_properties)
+
+
+    def is_expected_jdk(self):
+        """
+        Return True if jdk is as expected, otherwise assert.
+        :return: True if jdk is as expected
+        """
+
+        return super(AMPod, self).is_expected_jdk(' '.join(['--' , 'java', '-version']))

--- a/cicd/forgeops-tests/lib/utils/amster_pod.py
+++ b/cicd/forgeops-tests/lib/utils/amster_pod.py
@@ -1,0 +1,89 @@
+# Copyright (c) 2016-2019 ForgeRock AS. Use of this source code is subject to the
+# Common Development and Distribution License (CDDL) that can be found in the LICENSE file
+
+"""
+Metadata related to kubernetes Amster pods
+"""
+
+# Lib imports
+import os
+# Framework imports
+from utils import kubectl, logger
+from utils.pod import Pod
+
+
+class AmsterPod(Pod):
+    PRODUCT_TYPE = 'amster'
+    ROOT = os.path.join(os.sep, 'opt', 'amster')
+    TEMP = os.path.join(ROOT, 'fr-tmp')
+
+    def __init__(self, name, manifest_filepath):
+        """
+        :param name: Pod name
+        :param manifest_filepath: Path to product manifest file
+        """
+
+        Pod.__init__(self, AmsterPod.PRODUCT_TYPE, name, manifest_filepath)
+        self.manifest['amster_jvm'] = self.config[self.product_type]['amster_jvm']
+
+    def is_expected_version(self):
+        """
+        Return True if the version is as expected, otherwise assert.
+        :return: True if the version is as expected.
+        """
+
+        stdout, stderr = kubectl.exec(' '.join([self.name, '--', './amster', '--version']))
+        version_strings = stdout[0].split()
+        version = version_strings[3].lstrip('v')
+        build = version_strings[5].rstrip(',')
+        jvm = version_strings[7]
+
+        logger.test_step('Check Amster version for pod: ' + self.name)
+        assert version == self.manifest['version'], 'Unexpected Amster version'
+        assert build == self.manifest['revision'], 'Unexpected Amster build revision'
+        assert jvm == self.manifest['amster_jvm'], 'Unexpected JVM for amster'
+        return True
+
+    def is_expected_legal_notices(self):
+        """
+        Return True if legal notices are as expected, otherwise assert.
+        :return: True if legal notices are as expected
+        """
+
+        legal_notices_directory = os.path.join(AmsterPod.ROOT, 'legal-notices')
+        return super(AmsterPod, self).is_expected_legal_notices(legal_notices_directory)
+
+
+    def setup_commons_check(self):
+        """Setup for checking commons library version"""
+
+        logger.debug('Setting up for commons version check')
+        amster_version_jar = 'amster-%s.jar' % self.manifest['version']
+        test_jar_filepath = os.path.join(AmsterPod.ROOT, amster_version_jar)
+        return super(AmsterPod, self).setup_commons_check(test_jar_filepath, AmsterPod.TEMP)
+
+    def cleanup_commons_check(self):
+        """Cleanup after checking commons library version"""
+
+        logger.debug('Cleaning up after commons version check')
+        return super(AmsterPod, self).cleanup_commons_check(AmsterPod.TEMP)
+
+    def is_expected_commons_version(self):
+        """
+        Return true if the commons version is as expected, otherwise return assert.
+        This check inspects a sample commons .jar to see what version is in use.
+        :return: True is the commons version is as expected.
+        """
+
+        logger.debug('Check commons version for config.jar')
+        config_jar_properties = os.path.join('META-INF', 'maven', 'org.forgerock.commons', 'config', 'pom.properties')
+        return super(AmsterPod, self).is_expected_commons_version(AmsterPod.TEMP, config_jar_properties)
+
+
+    def is_expected_jdk(self):
+        """
+        Return True if jdk is as expected, otherwise assert.
+        :return: True if jdk is as expected
+        """
+
+        return super(AmsterPod, self).is_expected_jdk(' '.join(['-c', 'amster', '--', 'java', '-version']))

--- a/cicd/forgeops-tests/lib/utils/kubectl.py
+++ b/cicd/forgeops-tests/lib/utils/kubectl.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2016-2019 ForgeRock AS. Use of this source code is subject to the
+# Common Development and Distribution License (CDDL) that can be found in the LICENSE file
+
+"""
+Utility wrapping the kubectl command
+"""
+
+# Lib imports
+import subprocess
+from kubernetes import client, config
+
+# Framework imports
+from utils import logger
+
+
+KUBECTL_COMMAND = 'kubectl'
+
+def exec(command):
+    """
+    Run a kubectl exec command
+    :param command: command to run
+    :return: (stdout, stderr) from running the command
+    """
+    command = ' '.join([KUBECTL_COMMAND, 'exec', command])
+    return __run_cmd_process(command)
+
+def get_product_pod_names(product, namespace):
+    """
+    Get the names of the pods for the given platform product
+    :param product: Name of platform product
+    :param namespace: Name of kubernetes namespace
+    :return: List of pod names
+    """
+    pods = __get_namespaced_pods(namespace)
+    pod_names = []
+    for pod in pods.items:
+        pod_name = pod.metadata.name
+        if product in pod_name:
+            pod_names.append(pod_name)
+    return pod_names
+
+def __get_namespaced_pods(namespace):
+
+    config.load_kube_config()
+    k8s_client = client.CoreV1Api()
+    pods = k8s_client.list_namespaced_pod(namespace)
+    for pod in pods.items:
+        logger.debug('%s\t%s\t%s' % (pod.status.pod_ip, pod.metadata.namespace, pod.metadata.name))
+    return pods
+
+def __run_cmd_process(cmd):
+    """
+    Run a command as process.  Checks the return code.
+    :param cmd: command to run
+    :return: (stdout, stderr)
+    """
+    logger.info('Running following command as process: ' + cmd)
+    response = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
+    stdout, stderr = response.communicate()
+    assert response.returncode == 0, ' Unexpected return code from Popen() ' + stderr
+    return (stdout.split('\n'), stderr.split('\n'))

--- a/cicd/forgeops-tests/lib/utils/pod.py
+++ b/cicd/forgeops-tests/lib/utils/pod.py
@@ -1,0 +1,165 @@
+# Copyright (c) 2016-2019 ForgeRock AS. Use of this source code is subject to the
+# Common Development and Distribution License (CDDL) that can be found in the LICENSE file
+
+"""
+Metadata related to kubernetes pods
+"""
+# Lib imports
+import os
+from configparser import ConfigParser
+import multiset
+
+# Framework imports
+from utils import logger, kubectl
+
+
+class Pod(object):
+
+    def __init__(self, product_type, name, manifest_filepath):
+        """
+        :param product_type: ForgeRock Platform product type
+        :param name: Pod name
+        :param manifest_filepath: Path to product manifest file
+        """
+        self._product_type = product_type
+        self._name = name
+        self._config = ConfigParser()
+        assert os.path.exists(manifest_filepath), 'Unable to locate ' + manifest_filepath
+        self._config.read(manifest_filepath)
+
+        self._manifest = {'version': self._config[product_type]["version"],
+                          'revision': self._config[product_type]["revision"],
+                          'date': self._config[product_type]["date"],
+                          'jdk_version': self._config[product_type]["jdk_version"],
+                          'jre_version': self._config[product_type]["jre_version"],
+                          'jdk_full_version': self._config[product_type]["jdk_full_version"],
+                          'commons_version': self._config[product_type]["commons_version"]}
+
+    @property
+    def product_type(self):
+        return self._product_type
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def config(self):
+        return self._config
+
+    @property
+    def manifest(self):
+        return self._manifest
+
+    @staticmethod
+    def is_expected_am_amster_version(am_manifest, amster_manifest):
+        """
+        :param am_manifest: Manifest of version information
+        :param amster_manifest: Manifest of version information
+        Return True if the AM and Amster versions match, otherwise assert.
+        :return: True if the versions are as expected.
+        """
+
+        logger.debug('Checking AM and Amster versions match')
+        assert am_manifest['version'] == amster_manifest['version'], 'AM and Amster versions should match'
+        assert am_manifest['revision'] == amster_manifest['revision'], 'AM and Amster build revisions should match'
+        assert am_manifest['date'] == amster_manifest['date'], 'AM and Amster build date should match'
+        assert am_manifest['commons_version'] == amster_manifest['commons_version'], 'AM and Amster commons version should match'
+
+        if am_manifest['jdk_version'] != amster_manifest['jdk_version']:
+            logger.warning("Different versions of java are in use.")
+
+
+    def is_expected_version(self):
+        """
+        Return True if the version is as expected, otherwise assert.
+        :return: True if the version is as expected.
+        """
+        assert False, 'Not implemented, please override in subclass'
+
+    def is_expected_legal_notices(self, legal_notices_path):
+        """
+        :param legal_notices_path: Path to legal notices
+        Return True if legal notices are as expected, otherwise assert.
+        :return: True if legal notices are as expected
+        """
+
+        default_legal_notices = set(self._config["DEFAULT"]["legal_notices"].split())
+        legal_notices = multiset.Multiset(self._config[self.product_type]["legal_notices"].split())
+        legal_notices += default_legal_notices
+
+        stdout, stderr =  kubectl.exec(' '.join([self.name, '-- ls -R ' + legal_notices_path]))
+        for line in stdout:
+            logger.debug('Found legal notice ' + self.name)
+            if line:
+                legal_notices.remove(line, 1)
+        assert len(legal_notices) == 0, 'Did not find all legal notices'
+        return True
+
+    def setup_commons_check(self):
+        """Setup for checking commons library version"""
+        assert False, 'Not implemented, please override in subclass'
+
+    def cleanup_commons_check(self):
+        """Cleanup after checking commons library version"""
+        assert False, 'Not implemented, please override in subclass'
+
+    def is_expected_commons_version(self):
+        """
+        Return true if the commons version is as expected, otherwise return assert.
+        This check inspects a sample commons .jar to see what version is in use.
+        :return: True is the commons version is as expected.
+        """
+        assert False, 'Not implemented, please override in subclass'
+
+
+    def setup_commons_check(self, filepath, temp_directory):
+        """
+        :param filepath Path to a common .jar
+        :param temp_directory directory used for exploding the sample .jar file
+        Setup for checking commons library version
+        """
+
+        logger.debug('Setting up for commons version check')
+        ignored = kubectl.exec(' '.join([self.name, '-- unzip', filepath, '-d', temp_directory]))
+
+    def cleanup_commons_check(self, temp_directory):
+        """
+        :param temp_directory Directory to be deleted
+        Cleanup after checking commons library version
+        """
+
+        logger.debug('Cleaning up after commons version check')
+        ignored, ignored = kubectl.exec(' '.join([self.name, '-- rm', '-rf', temp_directory]))
+
+    def is_expected_commons_version(self, subpath, temp_directory):
+        """
+        Return true if the commons version is as expected, otherwise return assert.
+        This check inspects a sample commons .jar to see what version is in use.
+        :return: True is the commons version is as expected.
+        """
+
+        test_filepath = os.path.join(temp_directory, subpath, temp_directory)
+        stdout, stderr = kubectl.exec \
+            (' '.join([self.name, '--', 'cat', test_filepath]))
+
+        logger.debug('Check commons version for: ' +  self.name)
+        assert stdout[2].strip() == 'version=' + self.manifest['commons_version'], 'Unexpected commons version'
+        assert stdout[3].strip() == 'groupId=org.forgerock.commons', ' Unexpected groupId for commons library'
+        return True
+
+
+    def is_expected_jdk(self, sub_command):
+        """
+        :param sub_command: Command passed onto kubectl to obtain jdk version information.
+        Return True if jdk is as expected, otherwise assert.
+        :return: True if jdk is as expected
+        """
+
+        stdout, stderr = kubectl.exec(' '.join([self.name, sub_command]))
+
+        logger.debug('Check JDK version for ' + self.name)
+        assert stderr[0].strip() == self.manifest['jdk_version'], 'Unexpected JDK in use'  # TODO: why stderr
+        assert stderr[1].strip() == self.manifest['jre_version'], 'Unexpected JRE in use'
+        assert stderr[2].strip() == self.manifest['jdk_full_version'], 'Unexpected JDK in use'
+        return True

--- a/cicd/forgeops-tests/tests/metadata/test_am_metadata.py
+++ b/cicd/forgeops-tests/tests/metadata/test_am_metadata.py
@@ -1,0 +1,84 @@
+# Copyright (c) 2016-2019 ForgeRock AS. Use of this source code is subject to the
+# Common Development and Distribution License (CDDL) that can be found in the LICENSE file
+
+"""
+Verify the versions of ForgeRock Product in use.
+"""
+
+# Lib imports
+import os
+import pytest
+
+# Framework imports
+from utils import logger, kubectl, pod, amster_pod
+from utils.am_pod import AMPod
+
+#TODO checksum check on docker images
+
+
+class TestAMMetadata(object):
+    MANIFEST_FILEPATH = os.path.join('config', '6.5.0-manifest.txt') # TODO:
+    pods = []
+
+    @classmethod
+    def setup_class(cls):
+        """Populate the lists of pods"""
+
+        logger.test_step('Get pods')
+        environment_properties = dict(os.environ)
+        podnames = kubectl.get_product_pod_names(AMPod.PRODUCT_TYPE, environment_properties.get('TESTS_NAMESPACE'))
+        assert len(podnames) > 0,  'There are no AM pods'
+        for podname in podnames:
+            TestAMMetadata.pods.append(AMPod(podname, TestAMMetadata.MANIFEST_FILEPATH))
+
+    def test_am_amster_versions(self):
+        """Check the AM and Amster versions match"""
+
+        logger.test_step('Check AM and Amster versions match')
+        representative_am_pod = TestAMMetadata.pods[0]
+        representative_amster_pod =  amster_pod.AmsterPod("representative_amster_pod", TestAMMetadata.MANIFEST_FILEPATH)
+        pod.Pod.is_expected_am_amster_version(representative_am_pod.manifest, representative_amster_pod.manifest)
+
+
+    @pytest.fixture()
+    def get_commons_library(self):
+        """Setup and cleanup for checking commons library version"""
+
+        for pod in TestAMMetadata.pods:
+            logger.test_step('Setting up for commons version check for: ' + pod.name)
+            pod.setup_commons_check()
+        yield
+        for pod in TestAMMetadata.pods:
+            logger.test_step('Cleaning up after commons version check for: ' + pod.name)
+            pod.cleanup_commons_check()
+
+    def test_commons_version(self, get_commons_library):
+        """Check the version of a commons library"""
+
+        logger.test_step('Check commons version')
+        for pod in TestAMMetadata.pods:
+            logger.info('Check commons version for: ' +  pod.name)
+            pod.is_expected_commons_version()
+
+
+    def test_legal_notices(self):
+        """Check the presence of legal-notices"""
+
+        logger.test_step('Check legal Notices')
+        for pod in TestAMMetadata.pods:
+            logger.info('Check the contents of the legal-notices for: ' + pod.name)
+            pod.is_expected_legal_notices()
+
+    def test_am_version(self):
+        """Check the AM version"""
+
+        representative_pod = TestAMMetadata.pods[0]
+        representative_pod.is_expected_version()
+
+    def test_pods_jdk(self):
+        """Check the JDK for the pods"""
+
+        logger.test_step('Check JDK version')
+        for pod in TestAMMetadata.pods:
+            logger.info('Check JDK version for ' + pod.name)
+            pod.is_expected_jdk()

--- a/cicd/forgeops-tests/tests/metadata/test_amster_metadata.py
+++ b/cicd/forgeops-tests/tests/metadata/test_amster_metadata.py
@@ -1,0 +1,84 @@
+# Copyright (c) 2016-2019 ForgeRock AS. Use of this source code is subject to the
+# Common Development and Distribution License (CDDL) that can be found in the LICENSE file
+
+"""
+Verify the versions of ForgeRock Product in use.
+"""
+
+# Lib imports
+import os
+import pytest
+
+# Framework imports
+from utils import logger, kubectl, pod, am_pod
+from utils.amster_pod import AmsterPod
+
+#TODO checksum check on docker images
+
+
+class TestAmsterMetadata(object):
+    MANIFEST_FILEPATH = os.path.join('config', '6.5.0-manifest.txt') # TODO:
+    pods = []
+
+    @classmethod
+    def setup_class(cls):
+        """Populate the lists of pods"""
+
+        logger.test_step('Get pods')
+        environment_properties = dict(os.environ)
+        podnames = kubectl.get_product_pod_names(AmsterPod.PRODUCT_TYPE, environment_properties.get('TESTS_NAMESPACE'))
+        assert len(podnames) > 0,  'There are no Amster pods'
+        for podname in podnames:
+            TestAmsterMetadata.pods.append(AmsterPod(podname, TestAmsterMetadata.MANIFEST_FILEPATH))
+
+    def test_am_amster_versions(self):
+        """Check the AM and Amster versions match"""
+
+        logger.test_step('Check AM and Amster versions match')
+        representative_amster_pod = TestAmsterMetadata.pods[0]
+        representative_am_pod =  am_pod.AMPod("representative_openam_pod", TestAmsterMetadata.MANIFEST_FILEPATH)
+        pod.Pod.is_expected_am_amster_version(representative_am_pod.manifest, representative_amster_pod.manifest)
+
+
+    @pytest.fixture()
+    def get_commons_library(self):
+        """Setup and cleanup for checking commons library version"""
+
+        for pod in TestAmsterMetadata.pods:
+            logger.test_step('Setting up for commons version check for: ' + pod.name)
+            pod.setup_commons_check()
+        yield
+        for pod in TestAmsterMetadata.pods:
+            logger.test_step('Cleaning up after commons version check for: ' + pod.name)
+            pod.cleanup_commons_check()
+
+    def test_commons_version(self, get_commons_library):
+        """Check the version of a commons library"""
+
+        logger.test_step('Check commons version')
+        for pod in TestAmsterMetadata.pods:
+            logger.info('Check commons version for: ' +  pod.name)
+            pod.is_expected_commons_version()
+
+
+    def test_legal_notices(self):
+        """Check the presence of legal-notices"""
+
+        logger.test_step('Check legal Notices')
+        for pod in TestAmsterMetadata.pods:
+            logger.info('Check the contents of the legal-notices for: ' + pod.name)
+            pod.is_expected_legal_notices()
+
+    def test_version(self):
+        """Check the version"""
+
+        representative_pod = TestAmsterMetadata.pods[0]
+        representative_pod.is_expected_version()
+
+    def test_pods_jdk(self):
+        """Check the JDK for the pods"""
+
+        logger.test_step('Check JDK version')
+        for pod in TestAmsterMetadata.pods:
+            logger.info('Check JDK version for ' + pod.name)
+            pod.is_expected_jdk()


### PR DESCRIPTION
Jira issue? <CLOUD-1076>
Release 6.5.0 backport required? <no>
6.5.0 doc changes needed? <no>
7.0.0 doc changes needed? <no>
Required README updates made? <no>

POC for checking data about the AM and Amster images e.g. version, jdk, presence of legal-notices.
An example manifest file is attached:
[6.5.0-manifest.txt](https://github.com/ForgeRock/forgeops/files/2822330/6.5.0-manifest.txt)

