### PR TITLE
Fix AM and IDM live check in deploy.sh when running in GKE

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -197,7 +197,10 @@ deploy_charts()
 
 isalive_check()
 {
-    PROTO="https"
+    PROTO="http"
+    if [ "${CONTEXT}" = "minikube" ]; then
+        PROTO="https"
+    fi
     ALIVE_JSP="${PROTO}://${AM_URL}/isAlive.jsp"
     echo "=> Testing ${ALIVE_JSP}"
     STATUS_CODE="503"
@@ -211,7 +214,10 @@ isalive_check()
 
 isalive_check_idm()
 {
-    PROTO="https"
+    PROTO="http"
+    if [ "${CONTEXT}" = "minikube" ]; then
+        PROTO="https"
+    fi
     IDM_PING_ENDPOINT="${PROTO}://${IDM_URL}/openidm/info/ping"
     echo "=> Testing ${IDM_PING_ENDPOINT}"
     STATUS_CODE="503"


### PR DESCRIPTION
Jira issue? none
Release 6.5.0 backport required? no
6.5.0 doc changes needed? no
7.0.0 doc changes needed? no
Required README updates made? no

The http protocol is not the same running in minikube and GKE.
Running in minikube we have to use `https` to have the AM and IDM live checks working => https://csovant.iam.forgeops.com/am/isAlive.jsp
But running in GKE we have to use `http` => http://csovant.iam.forgeops.com/am/isAlive.jsp