### PR TITLE
Smoke tests: always use https protocol

### DIFF
--- a/cicd/forgeops-tests/config/ProductConfig.py
+++ b/cicd/forgeops-tests/config/ProductConfig.py
@@ -45,10 +45,7 @@ def tests_domain():
 
 
 def base_url():
-    protocol = 'http'
-    if is_minikube_context():
-        protocol = 'https'
-    return '%s://%s.iam.%s' % (protocol, tests_namespace(), tests_domain())
+    return 'https://%s.iam.%s' % (tests_namespace(), tests_domain())
 
 
 class AMConfig(object):


### PR DESCRIPTION
Jira issue? none
Release 6.5.0 backport required? no
6.5.0 doc changes needed? no
7.0.0 doc changes needed? no
Required README updates made? no

This will fix the `test_3_oauth2_access_token` test