### PR TITLE
CLOUD-1076 Explicit -n for kubectl

### DIFF
--- a/cicd/forgeops-tests/config/6.5.0-manifest.txt
+++ b/cicd/forgeops-tests/config/6.5.0-manifest.txt
@@ -1,14 +1,7 @@
 [DEFAULT]
-legal_notices = Forgerock_License.txt copyrights.txt third-party-copyrights.txt third-party-licenses
-    Apache-2.0.txt BSD-2-Clause.txt BSD-3-Clause.txt BSD.txt Bouncy_Castle_License.txt
-    CC0-1.0.txt CDDL-1.0.txt CDDL-1.1.txt CDDL_or_GPLv2_with_exceptions.txt CPL-1.0.txt
-    EPL-1.0.txt JSON.txt MIT.txt MPL-2.0.txt
 version = 6.5.0
                  
 [openam]
-legal_notices = /usr/local/tomcat/webapps/am/legal-notices:
-    /usr/local/tomcat/webapps/am/legal-notices/third-party-licenses:
-    CDDL-1.0.txt
 version = 6.5.0
 revision = f8ac1261d9
 date = 2018-November-28 15:19
@@ -18,8 +11,6 @@ jdk_full_version = OpenJDK 64-Bit Server VM (build 25.191-b12, mixed mode)
 commons_version = 24.0.1
 
 [amster]
-legal_notices = /opt/amster/legal-notices:
-    /opt/amster/legal-notices/third-party-licenses:
 version = 6.5.0
 revision = f8ac1261d9
 date = 2018-November-28 15:19

--- a/cicd/forgeops-tests/lib/utils/am_pod.py
+++ b/cicd/forgeops-tests/lib/utils/am_pod.py
@@ -56,45 +56,44 @@ class AMPod(Pod):
         assert response.json()['date'] == self.manifest['date'], 'Unexpected AM build date'
         return True
 
-    def is_expected_legal_notices(self):
+    def setup_commons_check(self, namespace):
         """
-        Return True if legal notices are as expected, otherwise assert.
-        :return: True if legal notices are as expected
+        Setup for checking commons library version
+        :param namespace The kubernetes namespace.
         """
-
-        super(AMPod, self).is_expected_legal_notices(os.path.join(AMPod.ROOT, 'webapps', 'am', 'legal-notices'))
-
-
-    def setup_commons_check(self):
-        """Setup for checking commons library version"""
 
         logger.debug('Setting up for commons version check')
         config_version_jar = 'config-%s.jar' % self.manifest['commons_version']
         test_jar_filepath = os.path.join(AMPod.ROOT, 'webapps', 'am', 'WEB-INF', 'lib', config_version_jar)
-        return super(AMPod, self).setup_commons_check(test_jar_filepath, AMPod.TEMP)
+        super(AMPod, self).setup_commons_check(namespace, test_jar_filepath, AMPod.TEMP)
 
-    def cleanup_commons_check(self):
-        """Cleanup after checking commons library version"""
+    def cleanup_commons_check(self, namespace):
+        """
+        Cleanup after checking commons library version
+        :param namespace The kubernetes namespace.
+        """
 
         logger.debug('Cleaning up after commons version check')
-        return super(AMPod, self).cleanup_commons_check(AMPod.TEMP)
+        super(AMPod, self).cleanup_commons_check(namespace, AMPod.TEMP)
 
-    def is_expected_commons_version(self):
+    def is_expected_commons_version(self, namespace):
         """
         Return true if the commons version is as expected, otherwise return assert.
+        :param namespace The kubernetes namespace.
         This check inspects a sample commons .jar to see what version is in use.
         :return: True is the commons version is as expected.
         """
 
         config_jar_properties = os.path.join('META-INF', 'maven', 'org.forgerock.commons', 'config', 'pom.properties')
         logger.debug('Check commons version for config.jar')
-        return super(AMPod, self).is_expected_commons_version(AMPod.TEMP, config_jar_properties)
+        return super(AMPod, self).is_expected_commons_version(namespace, AMPod.TEMP, config_jar_properties)
 
 
-    def is_expected_jdk(self):
+    def is_expected_jdk(self, namespace):
         """
         Return True if jdk is as expected, otherwise assert.
+        :param namespace The kubernetes namespace.
         :return: True if jdk is as expected
         """
 
-        return super(AMPod, self).is_expected_jdk(' '.join(['--' , 'java', '-version']))
+        return super(AMPod, self).is_expected_jdk(namespace, ' '.join(['--' , 'java', '-version']))

--- a/cicd/forgeops-tests/lib/utils/kubectl.py
+++ b/cicd/forgeops-tests/lib/utils/kubectl.py
@@ -15,16 +15,16 @@ from utils import logger
 
 KUBECTL_COMMAND = 'kubectl'
 
-def exec(command):
+def exec(namespace, command):
     """
     Run a kubectl exec command
     :param command: command to run
     :return: (stdout, stderr) from running the command
     """
-    command = ' '.join([KUBECTL_COMMAND, 'exec', command])
+    command = ' '.join([KUBECTL_COMMAND, '-n', namespace, 'exec', command])
     return __run_cmd_process(command)
 
-def get_product_pod_names(product, namespace):
+def get_product_pod_names(namespace, product):
     """
     Get the names of the pods for the given platform product
     :param product: Name of platform product
@@ -54,7 +54,7 @@ def __run_cmd_process(cmd):
     :param cmd: command to run
     :return: (stdout, stderr)
     """
-    logger.info('Running following command as process: ' + cmd)
+    logger.debug('Running following command as process: ' + cmd)
     response = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
     stdout, stderr = response.communicate()
     assert response.returncode == 0, ' Unexpected return code from Popen() ' + stderr

--- a/cicd/forgeops-tests/lib/utils/pod.py
+++ b/cicd/forgeops-tests/lib/utils/pod.py
@@ -90,71 +90,48 @@ class Pod(object):
         """
         assert False, 'Not implemented, please override in subclass'
 
-    def is_expected_legal_notices(self, legal_notices_path):
+    def is_expected_legal_notices(self, namespace):
         """
-        :param legal_notices_path: Path to legal notices
-        Return True if legal notices are as expected, otherwise assert.
-        :return: True if legal notices are as expected
+        :param namespace The kubernetes namespace.
+        Return True if the representative license file is present on the pod, otherwise assert.
+        :return: True if file present
         """
 
-        default_legal_notices = set(self._config["DEFAULT"]["legal_notices"].split())
-        legal_notices = multiset.Multiset(self._config[self.product_type]["legal_notices"].split())
-        legal_notices += default_legal_notices
-
-        stdout, stderr =  kubectl.exec(' '.join([self.name, '-- ls -R ' + legal_notices_path]))
-        for line in stdout:
-            logger.debug('Found legal notice ' + self.name)
-            if line:
-                legal_notices.remove(line, 1)
-        assert len(legal_notices) == 0, 'Did not find all legal notices'
+        ignored, ignored =  kubectl.exec(namespace, ' '.join([self.name, '--', 'find', '.', '-name', 'Forgerock_License.txt']))
         return True
 
-    def setup_commons_check(self):
-        """Setup for checking commons library version"""
-        assert False, 'Not implemented, please override in subclass'
 
-    def cleanup_commons_check(self):
-        """Cleanup after checking commons library version"""
-        assert False, 'Not implemented, please override in subclass'
-
-    def is_expected_commons_version(self):
+    def setup_commons_check(self, namespace, filepath, temp_directory):
         """
-        Return true if the commons version is as expected, otherwise return assert.
-        This check inspects a sample commons .jar to see what version is in use.
-        :return: True is the commons version is as expected.
-        """
-        assert False, 'Not implemented, please override in subclass'
-
-
-    def setup_commons_check(self, filepath, temp_directory):
-        """
+        :param namespace The kubernetes namespace.
         :param filepath Path to a common .jar
         :param temp_directory directory used for exploding the sample .jar file
         Setup for checking commons library version
         """
 
         logger.debug('Setting up for commons version check')
-        ignored = kubectl.exec(' '.join([self.name, '-- unzip', filepath, '-d', temp_directory]))
+        ignored, ignored = kubectl.exec(namespace, ' '.join([self.name, '-- unzip', filepath, '-d', temp_directory]))
 
-    def cleanup_commons_check(self, temp_directory):
+    def cleanup_commons_check(self, namespace, temp_directory):
         """
+        :param namespace The kubernetes namespace.
         :param temp_directory Directory to be deleted
         Cleanup after checking commons library version
         """
 
         logger.debug('Cleaning up after commons version check')
-        ignored, ignored = kubectl.exec(' '.join([self.name, '-- rm', '-rf', temp_directory]))
+        ignored, ignored = kubectl.exec(namespace, ' '.join([self.name, '-- rm', '-rf', temp_directory]))
 
-    def is_expected_commons_version(self, subpath, temp_directory):
+    def is_expected_commons_version(self, namespace, subpath, temp_directory):
         """
+        :param namespace The kubernetes namespace.
         Return true if the commons version is as expected, otherwise return assert.
         This check inspects a sample commons .jar to see what version is in use.
         :return: True is the commons version is as expected.
         """
 
         test_filepath = os.path.join(temp_directory, subpath, temp_directory)
-        stdout, stderr = kubectl.exec \
-            (' '.join([self.name, '--', 'cat', test_filepath]))
+        stdout, stderr = kubectl.exec(namespace, ' '.join([self.name, '--', 'cat', test_filepath]))
 
         logger.debug('Check commons version for: ' +  self.name)
         assert stdout[2].strip() == 'version=' + self.manifest['commons_version'], 'Unexpected commons version'
@@ -162,14 +139,15 @@ class Pod(object):
         return True
 
 
-    def is_expected_jdk(self, sub_command):
+    def is_expected_jdk(self, namespace, sub_command):
         """
+        :param namespace The kubernetes namespace.
         :param sub_command: Command passed onto kubectl to obtain jdk version information.
         Return True if jdk is as expected, otherwise assert.
         :return: True if jdk is as expected
         """
 
-        stdout, stderr = kubectl.exec(' '.join([self.name, sub_command]))
+        stdout, stderr = kubectl.exec(namespace, ' '.join([self.name, sub_command]))
 
         logger.debug('Check JDK version for ' + self.name)
         assert stderr[0].strip() == self.manifest['jdk_version'], 'Unexpected JDK in use'  # TODO: why stderr

--- a/cicd/forgeops-tests/tests/metadata/test_am_metadata.py
+++ b/cicd/forgeops-tests/tests/metadata/test_am_metadata.py
@@ -18,6 +18,8 @@ from utils.am_pod import AMPod
 
 class TestAMMetadata(object):
     MANIFEST_FILEPATH = os.path.join(pod.Pod.test_root_directory(),'config', '6.5.0-manifest.txt')
+    environment_properties = dict(os.environ)
+    NAMESPACE= environment_properties.get('TESTS_NAMESPACE')
     pods = []
 
     @classmethod
@@ -25,8 +27,8 @@ class TestAMMetadata(object):
         """Populate the lists of pods"""
 
         logger.test_step('Get pods')
-        environment_properties = dict(os.environ)
-        podnames = kubectl.get_product_pod_names(AMPod.PRODUCT_TYPE, environment_properties.get('TESTS_NAMESPACE'))
+
+        podnames = kubectl.get_product_pod_names(TestAMMetadata.NAMESPACE, AMPod.PRODUCT_TYPE)
         assert len(podnames) > 0,  'There are no AM pods'
         for podname in podnames:
             TestAMMetadata.pods.append(AMPod(podname, TestAMMetadata.MANIFEST_FILEPATH))
@@ -46,11 +48,11 @@ class TestAMMetadata(object):
 
         for pod in TestAMMetadata.pods:
             logger.test_step('Setting up for commons version check for: ' + pod.name)
-            pod.setup_commons_check()
+            pod.setup_commons_check(TestAMMetadata.NAMESPACE)
         yield
         for pod in TestAMMetadata.pods:
             logger.test_step('Cleaning up after commons version check for: ' + pod.name)
-            pod.cleanup_commons_check()
+            pod.cleanup_commons_check(TestAMMetadata.NAMESPACE)
 
     def test_commons_version(self, get_commons_library):
         """Check the version of a commons library"""
@@ -58,7 +60,7 @@ class TestAMMetadata(object):
         logger.test_step('Check commons version')
         for pod in TestAMMetadata.pods:
             logger.info('Check commons version for: ' +  pod.name)
-            pod.is_expected_commons_version()
+            pod.is_expected_commons_version(TestAMMetadata.NAMESPACE)
 
 
     def test_legal_notices(self):
@@ -66,8 +68,8 @@ class TestAMMetadata(object):
 
         logger.test_step('Check legal Notices')
         for pod in TestAMMetadata.pods:
-            logger.info('Check the contents of the legal-notices for: ' + pod.name)
-            pod.is_expected_legal_notices()
+            logger.info('Check legal-notices exist for: ' + pod.name)
+            pod.is_expected_legal_notices(TestAMMetadata.NAMESPACE)
 
     def test_am_version(self):
         """Check the AM version"""
@@ -81,4 +83,4 @@ class TestAMMetadata(object):
         logger.test_step('Check JDK version')
         for pod in TestAMMetadata.pods:
             logger.info('Check JDK version for ' + pod.name)
-            pod.is_expected_jdk()
+            pod.is_expected_jdk(TestAMMetadata.NAMESPACE)

--- a/cicd/forgeops-tests/tests/metadata/test_amster_metadata.py
+++ b/cicd/forgeops-tests/tests/metadata/test_amster_metadata.py
@@ -18,6 +18,8 @@ from utils.amster_pod import AmsterPod
 
 class TestAmsterMetadata(object):
     MANIFEST_FILEPATH = os.path.join(pod.Pod.test_root_directory(), 'config', '6.5.0-manifest.txt')
+    environment_properties = dict(os.environ)
+    NAMESPACE= environment_properties.get('TESTS_NAMESPACE')
     pods = []
 
     @classmethod
@@ -25,8 +27,7 @@ class TestAmsterMetadata(object):
         """Populate the lists of pods"""
 
         logger.test_step('Get pods')
-        environment_properties = dict(os.environ)
-        podnames = kubectl.get_product_pod_names(AmsterPod.PRODUCT_TYPE, environment_properties.get('TESTS_NAMESPACE'))
+        podnames = kubectl.get_product_pod_names(TestAmsterMetadata.NAMESPACE, AmsterPod.PRODUCT_TYPE)
         assert len(podnames) > 0,  'There are no Amster pods'
         for podname in podnames:
             TestAmsterMetadata.pods.append(AmsterPod(podname, TestAmsterMetadata.MANIFEST_FILEPATH))
@@ -46,11 +47,11 @@ class TestAmsterMetadata(object):
 
         for pod in TestAmsterMetadata.pods:
             logger.test_step('Setting up for commons version check for: ' + pod.name)
-            pod.setup_commons_check()
+            pod.setup_commons_check(TestAmsterMetadata.NAMESPACE)
         yield
         for pod in TestAmsterMetadata.pods:
             logger.test_step('Cleaning up after commons version check for: ' + pod.name)
-            pod.cleanup_commons_check()
+            pod.cleanup_commons_check(TestAmsterMetadata.NAMESPACE)
 
     def test_commons_version(self, get_commons_library):
         """Check the version of a commons library"""
@@ -58,7 +59,7 @@ class TestAmsterMetadata(object):
         logger.test_step('Check commons version')
         for pod in TestAmsterMetadata.pods:
             logger.info('Check commons version for: ' +  pod.name)
-            pod.is_expected_commons_version()
+            pod.is_expected_commons_version(TestAmsterMetadata.NAMESPACE)
 
 
     def test_legal_notices(self):
@@ -66,14 +67,14 @@ class TestAmsterMetadata(object):
 
         logger.test_step('Check legal Notices')
         for pod in TestAmsterMetadata.pods:
-            logger.info('Check the contents of the legal-notices for: ' + pod.name)
-            pod.is_expected_legal_notices()
+            logger.info('Check legal-notices exist for: ' + pod.name)
+            pod.is_expected_legal_notices(TestAmsterMetadata.NAMESPACE)
 
     def test_version(self):
         """Check the version"""
 
         representative_pod = TestAmsterMetadata.pods[0]
-        representative_pod.is_expected_version()
+        representative_pod.is_expected_version(TestAmsterMetadata.NAMESPACE)
 
     def test_pods_jdk(self):
         """Check the JDK for the pods"""
@@ -81,4 +82,4 @@ class TestAmsterMetadata(object):
         logger.test_step('Check JDK version')
         for pod in TestAmsterMetadata.pods:
             logger.info('Check JDK version for ' + pod.name)
-            pod.is_expected_jdk()
+            pod.is_expected_jdk(TestAmsterMetadata.NAMESPACE)


### PR DESCRIPTION
Jira issue? <CLOUD-1076>
Release 6.5.0 backport required? no
6.5.0 doc changes needed? no
7.0.0 doc changes needed? no
Required README updates made? no

Make the calls to kubectl explicitly use a namespace.
Simplify the legal notice check.
Remove dead code in pod.py.