### PR TITLE
Makes the AM secret configurable

### DIFF
--- a/helm/openam/README.md
+++ b/helm/openam/README.md
@@ -35,5 +35,6 @@ The current approach is to copy in a prototype keystore from a k8s secret mounte
 are all configured to point to this keystore.  The global password secret provider must be changed to use clear text passwords to open the 
 keystore. This is found in the forgeops-init configuration that is imported by amster.
 
+### Using custom keystores
 
-
+You can override the default keystores in this chart by setting `existingSecrets.openamKeys` and `existingSecrets.openamKeystorePasswords` and providing your own secrets separately. This makes it easier to replace the default secrets without modifying this chart. Make sure to provide all required keys in these secrets.

--- a/helm/openam/templates/openam-deployment.yaml
+++ b/helm/openam/templates/openam-deployment.yaml
@@ -46,7 +46,7 @@ spec:
         volumeMounts:
         - name: openam-root
           mountPath: /home/forgerock/openam
-        - name: openam-secrets
+        - name: openam-keys
           mountPath: /var/run/secrets/openam
         - name: openam-boot
           mountPath: /var/run/openam
@@ -65,9 +65,9 @@ spec:
           mountPath: /home/forgerock/openam
         - name: configstore-secret
           mountPath: /var/run/secrets/configstore
-        - name: openam-secrets
+        - name: openam-keys
           mountPath: /var/run/secrets/openam/keystore
-        - name: openam-pstore-secrets
+        - name: openam-keystore-passwords
           mountPath: /var/run/secrets/openam/password
         {{ if eq .Values.config.strategy  "git" }}
         - name: git
@@ -128,12 +128,12 @@ spec:
       {{ end }}
       - name: openam-root
         emptyDir: {}
-      - name: openam-secrets
+      - name: openam-keys
         secret:
-          secretName: openam-secrets
-      - name: openam-pstore-secrets
+          secretName: {{ default "openam-keys" .Values.existingSecrets.openamKeys }}
+      - name: openam-keystore-passwords
         secret:
-          secretName: openam-pstore-secrets
+          secretName: {{ default "openam-keystore-passwords" .Values.existingSecrets.openamKeystorePasswords }}
       - name: openam-boot
         configMap:
           name: boot-json

--- a/helm/openam/templates/secrets.yaml
+++ b/helm/openam/templates/secrets.yaml
@@ -4,18 +4,22 @@
 # Note that secret values are base64-encoded.
 # The base64-encoded value of 'password' is 'cGFzc3dvcmQ='
 # Watch for trailing \n when you encode!
+{{- if (not .Values.existingSecrets.openamKeys) }}
 apiVersion: v1
 kind: Secret
 metadata:
-    name: "openam-secrets"
+    name: "openam-keys"
 type: Opaque
 data:
 {{ (.Files.Glob "secrets/*").AsSecrets| indent 2 }}
 ---
+{{- end }}
+{{- if (not .Values.existingSecrets.openamKeystorePasswords) }}
 apiVersion: v1
 kind: Secret
 metadata:
-    name: "openam-pstore-secrets"
+    name: "openam-keystore-passwords"
 type: Opaque
 data:
 {{ (.Files.Glob "secrets/*pass").AsSecrets| indent 2 }}
+{{- end }}

--- a/helm/openam/values.yaml
+++ b/helm/openam/values.yaml
@@ -92,6 +92,13 @@ amCustomizationScriptPath: "customize-am.sh"
 livenessPeriod: 60
 livenessTimeout: 15
 
+# Set the names below to provide custom secrets mounted in the AM pods (keystore, etc.). You must provide all secrets.
+# See templates/secrets.yaml and secrets/... for details
+existingSecrets: {}
+# existingSecrets: 
+#   openamKeys: openam-keys
+#   openamKeystorePasswords: openam-kesytore-passwords
+
 service:
   name: openam
   #type: NodePort


### PR DESCRIPTION
Jira issue? n/a
Release 6.5.0 backport required? yes
6.5.0 doc changes needed? no
7.0.0 doc changes needed? no
Required README updates made? yes

---

I followed the pattern used in https://github.com/helm/charts/tree/master/stable/mongodb
where the default secrets are only created if the user doesn't provide a custom secret via the `existingSecret` property. Here we need 2 separate secrets, so I made it a map rather than a single property.

I also changed the default secret names to make it less obscure what they're for