### PR TITLE
Cloud 1148 restore ingress hostname override

### DIFF
--- a/etc/istio/cluster-cert.yaml
+++ b/etc/istio/cluster-cert.yaml
@@ -13,11 +13,11 @@ spec:
   issuerRef:
     name: letsencrypt-prod
     kind: ClusterIssuer  
-  commonName: "*.iam.forgeops.com"
+  commonName: "*.istio.forgeops.com"
   acme:
     config:
     - dns01:
         provider:  prod-dns
       domains:
-      - "*.iam.forgeops.com"
+      - "*.istio.forgeops.com"
    

--- a/helm/openam/templates/_helpers.tpl
+++ b/helm/openam/templates/_helpers.tpl
@@ -29,7 +29,7 @@ We truncate at 24 chars because some Kubernetes name fields are limited to this
 {{- define "externalFQDN" -}}
 {{- if .Values.ingress.hostname  }}{{- printf "%s" .Values.ingress.hostname -}}
 {{- else -}}
-{{- printf "login.%s.%s" .Release.Namespace .Values.domain -}}
+{{- printf "%s.%s.%s" .Release.Namespace .Values.subdomain .Values.domain -}}
 {{- end -}}
 {{- end -}}
 

--- a/helm/openam/templates/ingress.yaml
+++ b/helm/openam/templates/ingress.yaml
@@ -19,11 +19,11 @@ metadata:
 spec:
   tls:
   - hosts:
-    - "{{ .Release.Namespace }}.{{.Values.subdomain }}.{{ .Values.domain }}"
+    -  {{ template "externalFQDN" .  }}
   # We default to using the nginx self signed cert.
   #   secretName: {{ printf "wildcard.%s.%s" .Release.Namespace .Values.domain }}
   rules:
-    - host: "{{ .Release.Namespace }}.{{.Values.subdomain }}.{{ .Values.domain }}"
+    - host:  {{ template "externalFQDN" .  }}
       http:
         paths:
         - path: /am


### PR DESCRIPTION
This restores the ability to override the external hostname of the AM ingress controller. 

Setting the variable ingress.hostname=my.custom.com  

Sets the external FQDN

This PR also includes a commit to set the istio subdomain for our shared cluster (no doc changes needed)

Jira issue? CLOUD-1148
Release 6.5.0 backport required? no
6.5.0 doc changes needed? no
7.0.0 doc changes needed?  no
Required README updates made? no