### PR TITLE
Allows certmanager to work with new URL scheme

### DIFF
--- a/helm/end-user-ui/templates/ingress.yaml
+++ b/helm/end-user-ui/templates/ingress.yaml
@@ -21,8 +21,7 @@ spec:
   tls:
   - hosts:
     - "{{ .Release.Namespace }}.{{.Values.subdomain }}.{{ .Values.domain }}"
-  # We default to using the nginx self signed cert.
-  #   secretName: {{ printf "wildcard.%s.%s" .Release.Namespace .Values.domain }}
+    secretName: '{{ .Release.Namespace }}.{{.Values.subdomain }}.{{ .Values.domain }}'
   rules:
     - host: "{{ .Release.Namespace }}.{{.Values.subdomain }}.{{ .Values.domain }}"
       http:

--- a/helm/frconfig/templates/cert-manager.yaml
+++ b/helm/frconfig/templates/cert-manager.yaml
@@ -8,7 +8,7 @@ spec:
   ca:
     secretName: certmanager-ca-secret
 ---
-# The CA certificate secret used by cert manager to issue certs. 
+# The CA certificate secret used by cert manager to issue certs.
 apiVersion: v1
 kind: Secret
 metadata:
@@ -21,20 +21,19 @@ data:
 # Requests cert manager create a certificate based on the Issuer (CA, lets encrypt, etc.)
 # A secret containing the cert will be created if the request is succesful. Ingress controllers
 # Should reference the secret by name in their tls spec.
-# We currently use a wildcard cert for each namespace.  *.namespace.domain 
 apiVersion: certmanager.k8s.io/v1alpha1
 kind: Certificate
 metadata:
-  name:  wildcard.{{ .Release.Namespace }}{{ .Values.domain }}
+  name:  '{{ .Release.Namespace }}.{{.Values.subdomain }}.{{ .Values.domain }}'
 spec:
-  secretName: {{ printf "wildcard.%s.%s" .Release.Namespace .Values.domain }}
+  secretName: '{{ .Release.Namespace }}.{{.Values.subdomain }}.{{ .Values.domain }}'
   issuerRef:
     name: {{ .Values.certmanager.issuer }}
     kind: {{ default "Issuer" .Values.certmanager.issuerKind }}
   # If commonName is not provided, the first value in dnsNames is used.
   #commonName: ""
   dnsNames:
-  - '*.{{ .Release.Namespace }}{{ .Values.domain }}'
+  - '{{ .Release.Namespace }}.{{.Values.subdomain }}.{{ .Values.domain }}'
   {{ if .Values.certmanager.acme -}}
   # This is used by Acme / Let's encrypt, and is ommited for CA certs.
   acme:
@@ -42,6 +41,6 @@ spec:
     - dns01:
         provider: prod-dns
       domains:
-      - '*.{{ .Release.Namespace }}{{ .Values.domain }}'
+      - '{{ .Release.Namespace }}.{{.Values.subdomain }}.{{ .Values.domain }}'
   {{ end }}
   {{ end }}

--- a/helm/openam/templates/ingress.yaml
+++ b/helm/openam/templates/ingress.yaml
@@ -20,8 +20,7 @@ spec:
   tls:
   - hosts:
     -  {{ template "externalFQDN" .  }}
-  # We default to using the nginx self signed cert.
-  #   secretName: {{ printf "wildcard.%s.%s" .Release.Namespace .Values.domain }}
+    secretName: '{{ .Release.Namespace }}.{{.Values.subdomain }}.{{ .Values.domain }}'
   rules:
     - host:  {{ template "externalFQDN" .  }}
       http:

--- a/helm/openidm/templates/ingress.yaml
+++ b/helm/openidm/templates/ingress.yaml
@@ -20,8 +20,7 @@ spec:
   tls:
   - hosts:
     - "{{ .Release.Namespace }}.{{.Values.subdomain }}.{{ .Values.domain }}"
-  # We default to using the nginx self signed cert.
-  #   secretName: {{ printf "wildcard.%s.%s" .Release.Namespace .Values.domain }}
+    secretName: '{{ .Release.Namespace }}.{{.Values.subdomain }}.{{ .Values.domain }}'
   rules:
     - host: "{{ .Release.Namespace }}.{{.Values.subdomain }}.{{ .Values.domain }}"
       http:

--- a/helm/openig/templates/ingress.yaml
+++ b/helm/openig/templates/ingress.yaml
@@ -20,8 +20,7 @@ spec:
   tls:
   - hosts:
     - "{{ .Release.Namespace }}.{{.Values.subdomain }}.{{ .Values.domain }}"
-  # We default to using the nginx self signed cert.
-  #   secretName: {{ printf "wildcard.%s.%s" .Release.Namespace .Values.domain }}
+    secretName: '{{ .Release.Namespace }}.{{.Values.subdomain }}.{{ .Values.domain }}'
   rules:
     - host: "{{ .Release.Namespace }}.{{.Values.subdomain }}.{{ .Values.domain }}"
       http:


### PR DESCRIPTION
By setting "certmanager.enabled" to true as an frconfig value, this will allow certmanager to produce certificates based on the ca.crt entry shipped within frconfig. This is beneficial for anyone using minikube that is interested in a stable SSL certificate.