### PR TITLE
Set SERVER_URI to /am in Amster pod to workaround a recent change in …

### DIFF
--- a/helm/amster/templates/config-map.yaml
+++ b/helm/amster/templates/config-map.yaml
@@ -48,3 +48,4 @@ data:
   AMADMIN_PASSWORD_HASHED: "{{ .Values.amadminPasswordHashed }}"
   DOMAIN: {{ .Values.domain }}
   COOKIE_DOMAIN: {{ trimPrefix "." .Values.domain }}
+  SERVER_URI: "/am"


### PR DESCRIPTION
…amster-install.sh script

Jira issue? none
Release 6.5.0 backport required? no
6.5.0 doc changes needed? no
7.0.0 doc changes needed? no
Required README updates made? no

In the Amster image, the `amster-install.sh` script set the default AM context to `/`.
But in AM image, AM product is deployed by default under `/am` context.
So Amter is not able to contact AM.
=> this is a workaround as the `amster-install.sh` script will be fixed soon.