### PR TITLE
updated URL to new format in EKS ingress script

### DIFF
--- a/bin/eks-create-ingress-cntlr.sh
+++ b/bin/eks-create-ingress-cntlr.sh
@@ -39,17 +39,11 @@ do
 
 done
 
-echo "=> Creating route53 records"
+echo "=> Creating route53 record"
 
-AM_URL="login.${EKS_CLUSTER_NS}.${ROUTE53_DOMAIN}"
-IDM_URL="openidm.${EKS_CLUSTER_NS}.${ROUTE53_DOMAIN}"
-IG_URL="openig.${EKS_CLUSTER_NS}.${ROUTE53_DOMAIN}"
-GATLING_URL="gatling.${EKS_CLUSTER_NS}.${ROUTE53_DOMAIN}"
+URL="${EKS_CLUSTER_NS}.iam.${ROUTE53_DOMAIN}"
 
 NLB_DNS=$(kubectl --namespace nginx get services nginx-nginx-ingress-controller --no-headers -o custom-columns=NAME:.status.loadBalancer.ingress[0].hostname)
 
 HOSTED_ZONE_ID=$(aws route53 list-hosted-zones-by-name --dns-name ${ROUTE53_DOMAIN} --query 'HostedZones[0].Id' | sed s/\"//g | sed s/,//g | sed s./hostedzone/..g)
-aws route53 change-resource-record-sets --hosted-zone-id ${HOSTED_ZONE_ID} --change-batch '{"Comment":"UPSERT a record ","Changes":[{"Action":"UPSERT","ResourceRecordSet":{"Name":"'"${AM_URL}"'","Type":"CNAME","TTL":300,"ResourceRecords":[{"Value":"'"${NLB_DNS}"'"}]}}]}'
-aws route53 change-resource-record-sets --hosted-zone-id ${HOSTED_ZONE_ID} --change-batch '{"Comment":"UPSERT a record ","Changes":[{"Action":"UPSERT","ResourceRecordSet":{"Name":"'"${IDM_URL}"'","Type":"CNAME","TTL":300,"ResourceRecords":[{"Value":"'"${NLB_DNS}"'"}]}}]}'
-aws route53 change-resource-record-sets --hosted-zone-id ${HOSTED_ZONE_ID} --change-batch '{"Comment":"UPSERT a record ","Changes":[{"Action":"UPSERT","ResourceRecordSet":{"Name":"'"${IG_URL}"'","Type":"CNAME","TTL":300,"ResourceRecords":[{"Value":"'"${NLB_DNS}"'"}]}}]}'
-aws route53 change-resource-record-sets --hosted-zone-id ${HOSTED_ZONE_ID} --change-batch '{"Comment":"UPSERT a record ","Changes":[{"Action":"UPSERT","ResourceRecordSet":{"Name":"'"${GATLING_URL}"'","Type":"CNAME","TTL":300,"ResourceRecords":[{"Value":"'"${NLB_DNS}"'"}]}}]}'
+aws route53 change-resource-record-sets --hosted-zone-id ${HOSTED_ZONE_ID} --change-batch '{"Comment":"UPSERT a record ","Changes":[{"Action":"UPSERT","ResourceRecordSet":{"Name":"'"${URL}"'","Type":"CNAME","TTL":300,"ResourceRecords":[{"Value":"'"${NLB_DNS}"'"}]}}]}'


### PR DESCRIPTION
Jira issue? CLOUD-1115
Release 6.5.0 backport required? no
6.5.0 doc changes needed? no
7.0.0 doc changes needed? yes
need to update 2.6.4 in EKS CDM cookbook to reflect change.  Only 1 record required now instead of mutiple.
Required README updates made? no

This change updates the ingress script to use the new URL format. 