### PR TITLE
CLOUD-1173 Add IG metadata checks

### DIFF
--- a/cicd/forgeops-tests/lib/utils/am_pod.py
+++ b/cicd/forgeops-tests/lib/utils/am_pod.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2019 ForgeRock AS. Use of this source code is subject to the
+# Copyright (c) 2019 ForgeRock AS. Use of this source code is subject to the
 # Common Development and Distribution License (CDDL) that can be found in the LICENSE file
 
 """

--- a/cicd/forgeops-tests/lib/utils/amster_pod.py
+++ b/cicd/forgeops-tests/lib/utils/amster_pod.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2019 ForgeRock AS. Use of this source code is subject to the
+# Copyright (c) 2019 ForgeRock AS. Use of this source code is subject to the
 # Common Development and Distribution License (CDDL) that can be found in the LICENSE file
 
 """
@@ -34,7 +34,7 @@ class AmsterPod(Pod):
         :return: Dictionary
         """
 
-        logger.test_step('Check Amster version for pod {name}'.format(name=self.name))
+        logger.test_step('Report Amster version for pod {name}'.format(name=self.name))
         stdout, ignored = kubectl.exec(
             Pod.NAMESPACE, [self.name, '--', './amster', '-c', self.product_type, '--version'])
         version_text = stdout[0].strip()
@@ -89,8 +89,8 @@ class AmsterPod(Pod):
         logger.debug('Checking commons version in {path}'.format(path=test_jar_properties_path))
         assert os.path.isfile(test_jar_properties_path), 'Failed to find {path}'.format(path=test_jar_properties_path)
 
-        with open(test_jar_properties_path) as fp:
-            lines = fp.readlines()
+        with open(test_jar_properties_path) as file_pointer:
+            lines = file_pointer.readlines()
 
         attribute_of_interest = {'version', 'groupId', 'artifactId'}
         os_metadata = Pod.get_metadata_of_interest('Commons', self.name, lines, attribute_of_interest)

--- a/cicd/forgeops-tests/lib/utils/ds_pod.py
+++ b/cicd/forgeops-tests/lib/utils/ds_pod.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2019 ForgeRock AS. Use of this source code is subject to the
+# Copyright (c) 2019 ForgeRock AS. Use of this source code is subject to the
 # Common Development and Distribution License (CDDL) that can be found in the LICENSE file
 
 """
@@ -73,11 +73,11 @@ class DSPod(Pod):
         logger.debug('Checking commons version in {path}'.format(path=test_jar_properties_path))
         assert os.path.isfile(test_jar_properties_path), 'Failed to find {path}'.format(path=test_jar_properties_path)
 
-        with open(test_jar_properties_path) as fp:
-            lines = fp.readlines()
+        with open(test_jar_properties_path) as file_pointer:
+            lines = file_pointer.readlines()
 
-        attribute_of_interest = {'version', 'groupId', 'artifactId'}
-        os_metadata = Pod.get_metadata_of_interest('Commons', self.name, lines, attribute_of_interest)
+        attributes_of_interest = {'version', 'groupId', 'artifactId'}
+        os_metadata = Pod.get_metadata_of_interest('Commons', self.name, lines, attributes_of_interest)
         Pod.print_table(os_metadata)
 
     def log_jdk(self):

--- a/cicd/forgeops-tests/lib/utils/idm_pod.py
+++ b/cicd/forgeops-tests/lib/utils/idm_pod.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2019 ForgeRock AS. Use of this source code is subject to the
+# Copyright (c) 2019 ForgeRock AS. Use of this source code is subject to the
 # Common Development and Distribution License (CDDL) that can be found in the LICENSE file
 
 """

--- a/cicd/forgeops-tests/lib/utils/ig_pod.py
+++ b/cicd/forgeops-tests/lib/utils/ig_pod.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2019 ForgeRock AS. Use of this source code is subject to the
+# Common Development and Distribution License (CDDL) that can be found in the LICENSE file
+
+"""
+Metadata related to a kubernetes AM pod.
+"""
+
+# Lib imports
+import os
+
+# Framework imports
+from utils import logger, kubectl
+from utils.pod import Pod
+
+
+class IGPod(Pod):
+    PRODUCT_TYPE = 'openig'
+    REPRESENTATIVE_COMMONS_JAR_NAME = 'config'
+    ROOT = os.path.join(os.sep, 'usr', 'local', 'tomcat')
+
+    def __init__(self, name):
+        """
+        :param name: Pod name
+        """
+        super().__init__(IGPod.PRODUCT_TYPE, name)
+
+    def version(self):
+        """
+        Return the product version information.
+        :return: Dictionary
+        """
+
+        logger.test_step('Report IG version for pod {name}'.format(name=self.name))
+
+
+        test_jar_properties_path = os.path.join(IGPod.ROOT, 'webapps', 'ROOT', 'META-INF', 'maven', 'org.forgerock.openig', 'openig-war',
+                                                'pom.properties')
+        attributes_of_interest = {'version', 'groupId', 'artifactId'}
+        metadata, ignored = kubectl.exec(
+            Pod.NAMESPACE, [self.name, '-c', self.product_type, '--', 'cat', test_jar_properties_path])
+        version_metadata = Pod.get_metadata_of_interest(self.product_type, self.name, metadata, attributes_of_interest)
+        return version_metadata
+
+    def log_commons_version(self):
+        """Report version of commons for pod's forgerock product."""
+
+        logger.debug('Report commons version for {name}'.format(name=self.name))
+        representative_commons_jar = IGPod.REPRESENTATIVE_COMMONS_JAR_NAME
+        lib_path = os.path.join(os.sep, 'usr', 'local', 'tomcat', 'webapps', 'ROOT', 'WEB-INF', 'lib', )
+        super(IGPod, self).log_versioned_commons_jar(lib_path, representative_commons_jar)
+
+    def log_jdk(self):
+        """Report Java version on the pod."""
+
+        logger.debug('Report Java version for {name}'.format(name=self.name))
+        return super(IGPod, self).log_jdk({'openjdk version', 'openjdk version', 'openjdk version'})
+
+    def log_os(self):
+        """Report Operating System on the pod."""
+
+        logger.debug('Report OS version for {name}'.format(name=self.name))
+        super(IGPod, self).log_os({'NAME', 'ID', 'VERSION_ID'})        

--- a/cicd/forgeops-tests/lib/utils/kubectl.py
+++ b/cicd/forgeops-tests/lib/utils/kubectl.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2019 ForgeRock AS. Use of this source code is subject to the
+# Copyright (c) 2019 ForgeRock AS. Use of this source code is subject to the
 # Common Development and Distribution License (CDDL) that can be found in the LICENSE file
 
 """

--- a/cicd/forgeops-tests/lib/utils/pod.py
+++ b/cicd/forgeops-tests/lib/utils/pod.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2019 ForgeRock AS. Use of this source code is subject to the
+# Copyright (c) 2019 ForgeRock AS. Use of this source code is subject to the
 # Common Development and Distribution License (CDDL) that can be found in the LICENSE file
 
 """

--- a/cicd/forgeops-tests/tests/metadata/test_am_metadata.py
+++ b/cicd/forgeops-tests/tests/metadata/test_am_metadata.py
@@ -31,7 +31,7 @@ class TestAMMetadata(object):
 
         logger.test_step('Report the version')
         representative_pod = TestAMMetadata.pods[0]
-        logger.info('Report commons version for {name}'.format(name=representative_pod.name))
+        logger.info('Report version for {name}'.format(name=representative_pod.name))
         representative_pod.log_version()
 
     def test_commons_version(self):

--- a/cicd/forgeops-tests/tests/metadata/test_amster_metadata.py
+++ b/cicd/forgeops-tests/tests/metadata/test_amster_metadata.py
@@ -28,6 +28,14 @@ class TestAmsterMetadata(object):
         for podname in podnames:
             TestAmsterMetadata.pods.append(AmsterPod(podname))
 
+    def test_version(self):
+        """Report the version"""
+
+        logger.test_step('Report the version')
+        for amster_pod in TestAmsterMetadata.pods:
+            logger.info('Report the version for {name}'.format(name=amster_pod.name))
+            amster_pod.log_version()
+
     @pytest.fixture()
     def get_commons_library(self):
         """Setup and cleanup for checking commons library version"""
@@ -55,14 +63,6 @@ class TestAmsterMetadata(object):
         for amster_pod in TestAmsterMetadata.pods:
             logger.info('Check legal-notices exist for {name}'.format(name=amster_pod.name))
             amster_pod.are_legal_notices_present()
-
-    def test_version(self):
-        """Report the version"""
-
-        logger.test_step('Report version')
-        for amster_pod in TestAmsterMetadata.pods:
-            logger.info('Report JDK version for {name}'.format(name=amster_pod.name))
-            amster_pod.log_version()
 
     def test_pods_jdk(self):
         """Report the JDK running in the pods"""

--- a/cicd/forgeops-tests/tests/metadata/test_ds_metadata.py
+++ b/cicd/forgeops-tests/tests/metadata/test_ds_metadata.py
@@ -31,8 +31,9 @@ class TestDSMetadata(object):
     def test_version(self):
         """Report the version"""
 
-        logger.test_step('Report product version')
+        logger.test_step('Report the version')
         for ds_pod in TestDSMetadata.pods:
+            logger.info('Report the version for {name}'.format(name=ds_pod.name))
             ds_pod.log_version()
 
     @pytest.fixture()

--- a/cicd/forgeops-tests/tests/metadata/test_ig_metadata.py
+++ b/cicd/forgeops-tests/tests/metadata/test_ig_metadata.py
@@ -8,10 +8,10 @@ Verify the versions of ForgeRock Product in use.
 # Lib imports
 # Framework imports
 from utils import logger, kubectl, pod
-from utils.idm_pod import IDMPod
+from utils.ig_pod import IGPod
 
 
-class TestIDMMetadata(object):
+class TestIGMetadata(object):
     pods = []
 
     @classmethod
@@ -19,47 +19,47 @@ class TestIDMMetadata(object):
         """Populate the lists of pods"""
 
         logger.test_step('Get pods')
-        podnames = kubectl.get_product_component_names(pod.Pod.NAMESPACE, IDMPod.PRODUCT_TYPE)
-        assert len(podnames) > 0,  'There are no IDM pods'
+        podnames = kubectl.get_product_component_names(pod.Pod.NAMESPACE, IGPod.PRODUCT_TYPE)
+        assert len(podnames) > 0,  'There are no IG pods'
         for podname in podnames:
-            TestIDMMetadata.pods.append(IDMPod(podname))
+            TestIGMetadata.pods.append(IGPod(podname))
 
     def test_version(self):
         """Report the version"""
 
         logger.test_step('Report the version')
-        representative_pod = self.pods[0]
-        logger.info('Report the version for {name}'.format(name=representative_pod.name))
-        representative_pod.log_version()
+        for ig_pod in TestIGMetadata.pods:
+            logger.info('Report the version for {name}'.format(name=ig_pod.name))
+            ig_pod.log_version()
 
     def test_commons_version(self):
         """Report the commons version"""
 
         logger.test_step('Report the commons version')
-        for idm_pod in TestIDMMetadata.pods:
-            logger.info('Report commons version for {name}'.format(name=idm_pod.name))
-            idm_pod.log_commons_version()
+        for ig_pod in TestIGMetadata.pods:
+            logger.info('Report commons version for {name}'.format(name=ig_pod.name))
+            ig_pod.log_commons_version()
 
     def test_legal_notices(self):
         """Report the presence of legal-notices"""
 
         logger.test_step('Check legal Notices')
-        for idm_pod in TestIDMMetadata.pods:
-            logger.info('Check legal-notices exist for {name}'.format(name=idm_pod.name))
-            idm_pod.are_legal_notices_present()
+        for ig_pod in TestIGMetadata.pods:
+            logger.info('Check legal-notices exist for {name}'.format(name=ig_pod.name))
+            ig_pod.are_legal_notices_present()
 
     def test_jdk_version(self):
         """Report Java running in the pods"""
 
         logger.test_step('Report the Java version')
-        for idm_pod in TestIDMMetadata.pods:
-            logger.info('Report Java version for {name}'.format(name=idm_pod.name))
-            idm_pod.log_jdk()
+        for ig_pod in TestIGMetadata.pods:
+            logger.info('Report Java version for {name}'.format(name=ig_pod.name))
+            ig_pod.log_jdk()
 
     def test_image_os(self):
         """Check the OS running in the pods"""
 
         logger.test_step('Report the operating system')
-        for idm_pod in TestIDMMetadata.pods:
-            logger.info('Report OS for {name}'.format(name=idm_pod.name))
-            idm_pod.log_os()
+        for ig_pod in TestIGMetadata.pods:
+            logger.info('Report OS for {name}'.format(name=ig_pod.name))
+            ig_pod.log_os()


### PR DESCRIPTION
Jira issue? CLOUD-1173
Release 6.5.0 backport required? no
6.5.0 doc changes needed? no
7.0.0 doc changes needed? no
Required README updates made? no

Add metadata reporting/checks for IG.
Also some associated corrections elsewhere.