### PR TITLE
added gatling folder for results to match path

### DIFF
--- a/helm/gatling-benchmark/templates/gatling.yaml
+++ b/helm/gatling-benchmark/templates/gatling.yaml
@@ -58,12 +58,12 @@ spec:
             -Doauth2_client_id={{ .Values.benchmark.oauth2_client_id }}
             -Doauth2_client_pw={{ .Values.benchmark.oauth2_client_pw }}
             '
-            -g '-m -s TESTNAME -rd TESTNAME' &&
-            export FN=$(ls -t /opt/gatling/results | head -1) && tar -czvf /opt/gatling/results/$FN.tar.gz
-            /opt/gatling/results/$FN
+            -g '-m -s TESTNAME -rd TESTNAME' && mkdir -p /opt/gatling/results/gatling &&
+            export FN=$(ls -t /opt/gatling/results | head -1) && tar -czvf /opt/gatling/results/gatling/${FN}.tar.gz
+            /opt/gatling/results/${FN} &&  cp -a /opt/gatling/results/${FN} /opt/gatling/results/gatling
         volumeMounts:
           - name: gatling-results
-            mountPath: "/opt/gatling/results"
+            mountPath: "/opt/gatling/results/gatling"
           {{ if eq .Values.config.strategy  "git" }}
           - name: git
             mountPath: /git


### PR DESCRIPTION
Jira issue? CLOUD-1126
Release 6.5.0 backport required? no
6.5.0 doc changes needed? no
7.0.0 doc changes needed? no
Required README updates made? no

This is to fix an issue following a previous PR for this JIRA which aligned the FQDN with context with the other products.  The report links were broken as they were still on the root context so thats been fixed here.
