### PR TITLE
changed tag to 6.5.1 for all products

### DIFF
--- a/docker/csv/dev.csv
+++ b/docker/csv/dev.csv
@@ -1,8 +1,8 @@
 java,6.5.1,6.5.1
-ds,6.5.1-RC2,6.5.1-RC2
-openam,6.5.1-M2,6.5.1-M2
-amster,6.5.1-M2,6.5.1-M2
-openig,6.5.1-RC4,6.5.1-RC4
+ds,6.5.1-RC2,6.5.1
+openam,6.5.1-M2,6.5.1
+amster,6.5.1-M2,6.5.1
+openig,6.5.1-RC4,6.5.1
 openidm,6.5.0,6.5.1
 git,6.5.1,6.5.1
 nginx-agent,6.5.1,6.5.1


### PR DESCRIPTION
Jira issue? CLOUD-1154
Release 6.5.0 backport required? no
6.5.0 doc changes needed? no
7.0.0 doc changes needed? no
Required README updates made? no

I originally tagged the images with milestone. Warren mentioned to tag with just 6.5.1.
