### PR TITLE
aligns the use of default secrets in the ds, amster and openam acharts

### DIFF
--- a/helm/amster/templates/secrets.yaml
+++ b/helm/amster/templates/secrets.yaml
@@ -4,6 +4,7 @@
 # Note that secret vals are base64-encoded.
 # The base64-encoded value of 'password' is 'cGFzc3dvcmQ='.
 # Watch for trailing \n when you encode!
+{{ if .Values.useDefaultSecrets }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -11,3 +12,4 @@ metadata:
 type: Opaque
 data:
 {{ (.Files.Glob "secrets/*").AsSecrets| indent 2 }}
+{{ end }}

--- a/helm/amster/values.yaml
+++ b/helm/amster/values.yaml
@@ -99,3 +99,10 @@ resources:
 
 # ctsPassword - defaults to "password"
 #ctsPassword: password
+
+# If useDefaultSecrets is set to true (the default), the secret values in templates/secrets will be used 
+# to create the secret amster-secrets. If you set useDefaultSecrets to false, you must create these 
+# secrets yourself. This allows you to inject your own secrets rather than use the default ones bundled 
+# in the chart. An alternate strategy is to fork this chart and replace the secrets in templates/secrets 
+# with your own.
+useDefaultSecrets: true

--- a/helm/openam/README.md
+++ b/helm/openam/README.md
@@ -35,6 +35,6 @@ The current approach is to copy in a prototype keystore from a k8s secret mounte
 are all configured to point to this keystore.  The global password secret provider must be changed to use clear text passwords to open the 
 keystore. This is found in the forgeops-init configuration that is imported by amster.
 
-### Using custom keystores
+### Using custom secrets
 
-You can override the default keystores in this chart by setting `existingSecrets.openamKeys` and `existingSecrets.openamKeystorePasswords` and providing your own secrets separately. This makes it easier to replace the default secrets without modifying this chart. Make sure to provide all required keys in these secrets.
+If `useDefaultSecrets` is set to `true` (the default), the secret values in `templates/secrets` will be used to create the secrets `openam-keys` and `openam-keystore-passwords`. If you set useDefaultSecrets to false, you must create these secrets yourself. This allows you to inject your own secrets rather than use the default ones bundled in the chart. An alternate strategy is to fork this chart and replace the secrets in `templates/secrets` with your own.

--- a/helm/openam/templates/openam-deployment.yaml
+++ b/helm/openam/templates/openam-deployment.yaml
@@ -153,10 +153,10 @@ spec:
         emptyDir: {}
       - name: openam-keys
         secret:
-          secretName: {{ default "openam-keys" .Values.existingSecrets.openamKeys }}
+          secretName: openam-keys
       - name: openam-keystore-passwords
         secret:
-          secretName: {{ default "openam-keystore-passwords" .Values.existingSecrets.openamKeystorePasswords }}
+          secretName: openam-keystore-passwords
       - name: openam-boot
         configMap:
           name: boot-json

--- a/helm/openam/templates/secrets.yaml
+++ b/helm/openam/templates/secrets.yaml
@@ -4,7 +4,7 @@
 # Note that secret values are base64-encoded.
 # The base64-encoded value of 'password' is 'cGFzc3dvcmQ='
 # Watch for trailing \n when you encode!
-{{- if (not .Values.existingSecrets.openamKeys) }}
+{{- if .Values.useDefaultSecrets }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -13,8 +13,6 @@ type: Opaque
 data:
 {{ (.Files.Glob "secrets/*").AsSecrets| indent 2 }}
 ---
-{{- end }}
-{{- if (not .Values.existingSecrets.openamKeystorePasswords) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/helm/openam/values.yaml
+++ b/helm/openam/values.yaml
@@ -83,12 +83,12 @@ amCustomizationScriptPath: "customize-am.sh"
 livenessPeriod: 60
 livenessTimeout: 15
 
-# Set the names below to provide custom secrets mounted in the AM pods (keystore, etc.). You must provide all secrets.
-# See templates/secrets.yaml and secrets/... for details
-existingSecrets: {}
-# existingSecrets: 
-#   openamKeys: openam-keys
-#   openamKeystorePasswords: openam-kesytore-passwords
+# If useDefaultSecrets is set to true (the default), the secret values in templates/secrets will be used 
+# to create the secrets openam-keys and openam-keystore-passwords. If you set useDefaultSecrets to false, 
+# you must create these secrets yourself. This allows you to inject your own secrets rather than use the 
+# default ones bundled in the chart. An alternate strategy is to fork this chart and replace the secrets 
+# in templates/secrets with your own.
+useDefaultSecrets: true
 
 service:
   name: openam


### PR DESCRIPTION
forward port of https://github.com/ForgeRock/forgeops/pull/597 for release/6.5.1

Jira issue? n/a
Release 6.5.0 backport required? yes
6.5.0 doc changes needed? no
7.0.0 doc changes needed? no
Required README updates made? yes

I made a change recently to allow overriding the default AM secrets, then realized it is done differently in the ds chart. I changed the am chart to do the same (i.e. just a switch to turn off the default secrets), and added the same functionality to the amster chart. This makes all 3 charts nice and consistent.