### PR TITLE
add AM password to CDM amster values file

### DIFF
--- a/samples/config/prod/l-cluster/amster.yaml
+++ b/samples/config/prod/l-cluster/amster.yaml
@@ -8,9 +8,10 @@ config:
   #importPath: /git/config/6.5/default/am/empty-import
   exportPath: /tmp/amster
 
+amadminPassword: password
+
 ctsStores: ctsstore-0.ctsstore:1389,ctsstore-1.ctsstore:1389
 ctsPassword: password
-
 
 # For production set CPU limits to help Kube Schedule the pods.
 resources:

--- a/samples/config/prod/m-cluster/amster.yaml
+++ b/samples/config/prod/m-cluster/amster.yaml
@@ -9,6 +9,8 @@ config:
   #importPath: /git/config/6.5/default/am/empty-import
   exportPath: /tmp/amster
 
+amadminPassword: password
+
 ctsStores: ctsstore-0.ctsstore:1389,ctsstore-1.ctsstore:1389
 ctsPassword: password
 

--- a/samples/config/prod/s-cluster/amster.yaml
+++ b/samples/config/prod/s-cluster/amster.yaml
@@ -8,6 +8,8 @@ config:
   importPath: /git/config/6.5/cdm/m-cluster/am
   exportPath: /tmp/amster
 
+amadminPassword: password
+
 ctsStores: ctsstore-0.ctsstore:1389,ctsstore-1.ctsstore:1389
 ctsPassword: password
 


### PR DESCRIPTION
Jira issue? CLOUD-1186
Release 6.5.0 backport required? no
6.5.0 doc changes needed? no
7.0.0 doc changes needed? no
Required README updates made? no

Explicitly set the AM password for CDM samples because now it is randomised by default.
