### PR TITLE
adds an optional serviceAccountName variable to the amster chart

### DIFF
--- a/helm/amster/templates/amster.yaml
+++ b/helm/amster/templates/amster.yaml
@@ -21,6 +21,9 @@ spec:
         component:  {{ .Values.component }}
     spec:
       terminationGracePeriodSeconds: 5
+      {{- with .Values.serviceAccountName }}
+      serviceAccountName: {{ . }}
+      {{- end }}
       {{ if eq .Values.config.strategy "git" -}}
       initContainers:
       - name: git-init

--- a/helm/amster/values.yaml
+++ b/helm/amster/values.yaml
@@ -118,3 +118,5 @@ istio:
 #     :load /git/config/scripts/do_stuff.amster
 
 scripts: {}
+
+# serviceAccountName: my-amster-serviceaccount


### PR DESCRIPTION
Jira issue? n/a
Release 6.5.0 backport required? no
6.5.0 doc changes needed? no
7.0.0 doc changes needed? no
Required README updates made? n/a

This lets one crearte and set a service account for the amster pod with special access and/or pullsecrets.

also see https://github.com/ForgeRock/forgeops/pull/619 (release/6.5.1)