### PR TITLE
Remove ability to set schema

### DIFF
--- a/helm/openidm/templates/configmap.yaml
+++ b/helm/openidm/templates/configmap.yaml
@@ -25,7 +25,6 @@ data:
       openidm.repo.user={{.Values.openidm.repo.user}}
       openidm.repo.password={{.Values.openidm.repo.password}}
       openidm.repo.databaseName={{.Values.openidm.repo.databaseName}}
-      openidm.repo.schema={{.Values.openidm.repo.schema}}
 
       # This is here to suppress IDM crypting the password and writing out authentication.json
       openidm.anonymous.password=anonymous

--- a/helm/openidm/values.yaml
+++ b/helm/openidm/values.yaml
@@ -60,7 +60,6 @@ openidm:
      port: 5432
      user: openidm
      password: openidm
-     schema: openidm
      databaseName: openidm
   # Optional client secret for AM/IDM integration:
   idpconfig:


### PR DESCRIPTION
* OpenIDM internally doesn't allow the schema name to be different from
the database name, see org.forgerock.openidm.repo.jdbc.impl.JDBCRepoService