### PR TITLE
Changes required to make `cdk build ig` work

### DIFF
--- a/bin/cdk
+++ b/bin/cdk
@@ -17,7 +17,7 @@ bundles = {
     'am': ['dev/am'],
     'idm': ['dev/idm']
 }
-build_targets = ['am', 'amster', 'idm', 'ds-idrepo', 'ds-cts']
+build_targets = ['am', 'amster', 'idm', 'ds-idrepo', 'ds-cts', 'ig']
 
 def get_component_url(component, tag):
     """Calculates the target URL of the desired component"""

--- a/bin/utils.py
+++ b/bin/utils.py
@@ -29,7 +29,8 @@ DOCKER_REGEX_NAME = {
     'amster' : '.*amster.*',
     'idm': '.*idm',
     'ds-idrepo': '.*ds-idrepo.*',
-    'ds-cts': '.*ds-cts.*'
+    'ds-cts': '.*ds-cts.*',
+    'ig': '.*ig.*'
 }
 
 SCRIPT = pathlib.Path(__file__)

--- a/cicd/bin/set-deploy-images
+++ b/cicd/bin/set-deploy-images
@@ -25,4 +25,7 @@ kustomize edit set image ds-idrepo="${REGISTRY}/ds-idrepo:${TAG_NAME}"
 cd_or_die ../../kustomize/base/ds-cts
 kustomize edit set image ds-cts="${REGISTRY}/ds-cts:${TAG_NAME}"
 
+cd_or_die ../../kustomize/base/ig
+kustomize edit set image ig="${REGISTRY}/ig:${TAG_NAME}"
+
 $SCRIPT_DIR/../../bin/set-images --inplace --products rcs-agent ui --update-repo "${REGISTRY}" --update-tag "${TAG_NAME}"


### PR DESCRIPTION
This allows for custom docker build and setting image_defaulter entry for ig image.  Unsure if change to set-deploy-images is required or not