### PR TITLE
fix `IamLimitedAccess` policy

### DIFF
--- a/etc/aws-example-iam-policies/iam-limited-access.json
+++ b/etc/aws-example-iam-policies/iam-limited-access.json
@@ -27,11 +27,13 @@
                 "iam:DeleteOpenIDConnectProvider",
                 "iam:ListAttachedRolePolicies",
                 "iam:TagRole",
-                "iam:TagPolicy"
+                "iam:TagPolicy",
+                "logs:CreateLogGroup"
             ],
             "Resource": [
                 "arn:aws:iam::*:instance-profile/eksctl-*",
                 "arn:aws:iam::*:policy/*",
+                "arn:aws:logs:*::log-group:*",
                 "arn:aws:iam::*:role/eksctl-*",
                 "arn:aws:iam::*:oidc-provider/*",
                 "arn:aws:iam::*:role/aws-service-role/eks-nodegroup.amazonaws.com/AWSServiceRoleForAmazonEKSNodegroup",


### PR DESCRIPTION
Following the [ForgeOps / Setup for AWS](https://backstage.forgerock.com/docs/forgeops/7.3/cdm/eks/setup/aws-env.html) documentation, the [iam-limited-access.json](https://github.com/ForgeRock/forgeops/blob/fb6d0f5d2a6238aa146cd0f2c09e32d905e7786e/etc/aws-example-iam-policies/iam-limited-access.json) file doesn't contains all the necessary permission to be executed by [forgeops-extras](https://github.com/ForgeRock/forgeops-extras)