### PR TITLE
fix(idrepo): Pin ds image version to 7.4.2

### DIFF
--- a/charts/identity-platform/values.yaml
+++ b/charts/identity-platform/values.yaml
@@ -310,7 +310,7 @@ ldif_importer:
 
   image:
     repository: us-docker.pkg.dev/forgeops-public/images/ds
-    tag: latest
+    tag: 7.4.2
     pullPolicy: Always
     imagePullSecrets: []
 
@@ -755,7 +755,7 @@ ds_idrepo:
 
   image:
     repository: us-docker.pkg.dev/forgeops-public/images/ds
-    tag: latest
+    tag: 7.4.2
     pullPolicy: IfNotPresent
     imagePullSecrets: []
 
@@ -846,7 +846,7 @@ ds_cts:
 
   image:
     repository: us-docker.pkg.dev/forgeops-public/images/ds
-    tag: latest
+    tag: 7.4.2
     pullPolicy: IfNotPresent
     imagePullSecrets: []
 


### PR DESCRIPTION
The `idrepo` component was failing to deploy due to a Java version incompatibility. This was caused by the Helm chart using the `latest` tag for the `ds` Docker image, which was pulling a version built with a newer, incompatible version of Java.

This commit pins the image tag for `ds_idrepo`, `ds_cts`, and `ldif_importer` to `7.4.2` in `charts/identity-platform/values.yaml`. This ensures that a compatible version of the `ds` image is used, resolving the deployment issue.